### PR TITLE
chore: release Homey app v24.0.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -67,5 +67,14 @@
     "nl": "Bijgewerkt voor compatibiliteit met Node.js 22 en later.",
     "no": "Oppdatert for kompatibilitet med Node.js 22 og senere.",
     "sv": "Uppdaterad för kompatibilitet med Node.js 22 och senare."
+  },
+  "24.0.0": {
+    "da": "Tilføjet understøttelse af MELCloud Home-enheder; hvert klimaanlæg kan nu følge sin egen udetemperaturkilde (Homey-vejr som standard).",
+    "en": "Added support for MELCloud Home devices; each air conditioner can now follow its own outdoor temperature source (Homey weather by default).",
+    "es": "Añadida compatibilidad con dispositivos MELCloud Home; cada aire acondicionado puede seguir ahora su propia fuente de temperatura exterior (tiempo de Homey por defecto).",
+    "fr": "Ajout de la prise en charge des appareils MELCloud Home ; chaque climatiseur peut désormais suivre sa propre source de température extérieure (météo Homey par défaut).",
+    "nl": "Ondersteuning voor MELCloud Home-apparaten toegevoegd; elke airco kan nu zijn eigen buitentemperatuurbron volgen (Homey-weer als standaard).",
+    "no": "Lagt til støtte for MELCloud Home-enheter; hvert klimaanlegg kan nå følge sin egen utetemperaturkilde (Homey-vær som standard).",
+    "sv": "Lagt till stöd för MELCloud Home-enheter; varje luftkonditionering kan nu följa sin egen utomhustemperaturkälla (Homey-väder som standard)."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -130,5 +130,5 @@
       "värmepump"
     ]
   },
-  "version": "23.0.1"
+  "version": "24.0.0"
 }

--- a/app.json
+++ b/app.json
@@ -131,5 +131,5 @@
       "värmepump"
     ]
   },
-  "version": "23.0.1"
+  "version": "24.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "23.0.1",
+  "version": "24.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "23.0.1",
+      "version": "24.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "23.0.1",
+  "version": "24.0.0",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
Bumps the app to 24.0.0 with the store changelog entry (7 locales): MELCloud Home support and per-device outdoor temperature sources (Homey weather by default).

Once merged, the v24.0.0 tag + GitHub release triggers publish.yml (Homey App Store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)