### PR TITLE
fix: Homey-like form groups for the per-device source rows

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -27,7 +27,7 @@
                     <option data-i18n="settings.boolean.true" value="true">Yes</option>
                 </select>
             </div>
-            <div id="sources" class="homey-form-group"></div>
+            <div id="sources"></div>
             <div class="homey-form-group">
                 <button
                     id="refresh"

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -287,18 +287,32 @@ const createSourceSelect = (
   return select
 }
 
+// Homey design system idiom: the control nested inside its label
+// (same shape as the com.melcloud settings).
+const createSourceLabel = (
+  device: AdjustableDevice,
+  select: HTMLSelectElement,
+): HTMLLabelElement => {
+  const label = document.createElement('label')
+  label.classList.add('homey-form-label')
+  label.htmlFor = select.id
+  label.textContent = device.name
+  label.append(select)
+  return label
+}
+
+// One form group per field, following the Homey design system
 const appendSourceRow = (
   homey: Homey,
   device: AdjustableDevice,
   sensors: readonly TemperatureSensor[],
 ): void => {
-  const label = document.createElement('label')
-  label.classList.add('homey-form-label')
-  label.htmlFor = `source-${device.id}`
-  label.textContent = device.name
   const select = createSourceSelect(homey, device, sensors)
   sourceSelects.set(device.id, select)
-  sourcesElement.append(label, select)
+  const group = document.createElement('div')
+  group.classList.add('homey-form-group')
+  group.append(createSourceLabel(device, select))
+  sourcesElement.append(group)
 }
 
 const populateSources = async (homey: Homey): Promise<void> => {


### PR DESCRIPTION
The per-device selects were appended flat inside a single `homey-form-group`; the Homey design system (mirrored from the com.melcloud settings idiom) wants one group per field with the control nested inside its label — proper spacing and native look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)