### PR TITLE
chore: release Homey app v24.0.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -76,5 +76,14 @@
     "nl": "Ondersteuning voor MELCloud Home-apparaten toegevoegd; elke airco kan nu zijn eigen buitentemperatuurbron volgen (Homey-weer als standaard).",
     "no": "Lagt til støtte for MELCloud Home-enheter; hvert klimaanlegg kan nå følge sin egen utetemperaturkilde (Homey-vær som standard).",
     "sv": "Lagt till stöd för MELCloud Home-enheter; varje luftkonditionering kan nu följa sin egen utomhustemperaturkälla (Homey-väder som standard)."
+  },
+  "24.0.1": {
+    "da": "Forbedret udseendet af indstillingssiden.",
+    "en": "Improved the settings page appearance.",
+    "es": "Mejorada la apariencia de la página de ajustes.",
+    "fr": "Amélioration de l'apparence de la page de réglages.",
+    "nl": "Uiterlijk van de instellingenpagina verbeterd.",
+    "no": "Forbedret utseendet på innstillingssiden.",
+    "sv": "Förbättrat utseendet på inställningssidan."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -130,5 +130,5 @@
       "värmepump"
     ]
   },
-  "version": "24.0.0"
+  "version": "24.0.1"
 }

--- a/app.json
+++ b/app.json
@@ -131,5 +131,5 @@
       "värmepump"
     ]
   },
-  "version": "24.0.0"
+  "version": "24.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.0.0",
+  "version": "24.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.0.0",
+      "version": "24.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.0.0",
+  "version": "24.0.1",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
Settings page design fix for the store build (build 92 carries the flat layout — promote this one instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)