### PR TITLE
fix: Homey Style Library markup + self-arming Sonar step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,16 @@ jobs:
       - run: npm run format
     timeout-minutes: 15
   test:
-    # Coverage (with its 100% thresholds) only runs on the Node 22 leg —
-    # the Homey runtime version. The `latest` leg is non-blocking so a
-    # brand-new Node release cannot red the pipeline without any repo
-    # change. SonarCloud analyzes this repo in automatic-analysis mode
-    # (no CI step): switching to CI-based analysis requires disabling it
-    # and adding SONAR_TOKEN (see com.melcloud's ci.yml for the step).
+    # Coverage (with its 100% thresholds) and the Sonar upload only run on
+    # the Node 22 leg — the Homey runtime version. The `latest` leg is
+    # non-blocking so a brand-new Node release cannot red the pipeline
+    # without any repo change.
     continue-on-error: ${{ matrix.node-version == 'latest' }}
+    env:
+      # Job-level so the step `if` can gate on it (the secrets context is
+      # not available in step conditions): the Sonar upload self-arms the
+      # moment the SONAR_TOKEN secret exists.
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     name: Test (Node ${{ matrix.node-version }})
     permissions:
       contents: read
@@ -35,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
@@ -44,6 +48,8 @@ jobs:
         run: npm test -- --coverage
       - if: matrix.node-version != 22
         run: npm test
+      - if: matrix.node-version == 22 && env.SONAR_TOKEN != '' && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
     strategy:
       fail-fast: false
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,14 @@ to judge success.
   melcloud.mts only imports the source as a type — no runtime cycle.
 - `settings/index.mts` — browser-side settings UI, bundled by esbuild
   into `settings/index.mjs` (ES module). `onHomeyReady` is exposed via
-  `Object.assign(globalThis, { onHomeyReady })`.
+  `Object.assign(globalThis, { onHomeyReady })`. Settings pages and
+  widgets do NOT style the same way: settings follow the Homey Style
+  Library (`homey-form-*`/`homey-button-*`; in a `homey-form-group` the
+  control is a SIBLING after its label — see
+  custom-views/html-and-css-styling in the Homey docs), while widgets
+  get injected CSS variables and their own class set. Do not copy
+  markup across the two, nor from com.melcloud's settings (which nest
+  controls inside labels).
 - `homey-api-override.d.ts` — ambient module declaration for the
   homey-api surface actually used; `homey-override.d.ts` types the app
   settings. `lib/homey.mts` re-exports the runtime-provided `homey` SDK
@@ -123,7 +130,7 @@ to judge success.
   `.homeychangelog.json`.
 - Store submissions: a rejected version number cannot be resubmitted —
   bump the patch version.
-- Sonar: this repo runs SonarCloud in automatic-analysis mode (no CI
-  step — the two modes conflict). To get coverage on Sonar, disable
-  automatic analysis on sonarcloud.io, add the `SONAR_TOKEN` secret,
-  and restore the scan step from com.melcloud's ci.yml.
+- Sonar: the CI upload step self-arms on the `SONAR_TOKEN` secret (a
+  job-level env gate — the secrets context is not valid in step `if`).
+  Adding the secret requires disabling automatic analysis on
+  sonarcloud.io first (the two modes conflict).

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -287,8 +287,6 @@ const createSourceSelect = (
   return select
 }
 
-// Homey design system idiom: the control nested inside its label
-// (same shape as the com.melcloud settings).
 const createSourceLabel = (
   device: AdjustableDevice,
   select: HTMLSelectElement,
@@ -297,11 +295,11 @@ const createSourceLabel = (
   label.classList.add('homey-form-label')
   label.htmlFor = select.id
   label.textContent = device.name
-  label.append(select)
   return label
 }
 
-// One form group per field, following the Homey design system
+// Homey Style Library idiom (settings pages, unlike widgets, use it):
+// one form group per field, the control a SIBLING after its label.
 const appendSourceRow = (
   homey: Homey,
   device: AdjustableDevice,
@@ -311,7 +309,7 @@ const appendSourceRow = (
   sourceSelects.set(device.id, select)
   const group = document.createElement('div')
   group.classList.add('homey-form-group')
-  group.append(createSourceLabel(device, select))
+  group.append(createSourceLabel(device, select), select)
   sourcesElement.append(group)
 }
 


### PR DESCRIPTION
- Per the Homey docs (custom-views/html-and-css-styling), a `homey-form-group` places the control as a **sibling after its label** — not nested inside it (that was com.melcloud's local variation; widgets style differently altogether). CLAUDE.md now pins the settings-vs-widgets distinction.
- The SonarCloud upload step is back, aligned on com.melcloud, gated on a job-level `SONAR_TOKEN` env (the `secrets` context is invalid in step `if` — the parse failure we hit earlier): it self-arms once the secret is added (requires disabling automatic analysis on sonarcloud.io first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)