### PR TITLE
chore: release Homey app v24.0.2

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -85,5 +85,14 @@
     "nl": "Uiterlijk van de instellingenpagina verbeterd.",
     "no": "Forbedret utseendet på innstillingssiden.",
     "sv": "Förbättrat utseendet på inställningssidan."
+  },
+  "24.0.2": {
+    "da": "Justeret indstillingssiden efter Homey-stilbiblioteket.",
+    "en": "Aligned the settings page with the Homey style library.",
+    "es": "Página de ajustes alineada con la biblioteca de estilos de Homey.",
+    "fr": "Alignement de la page de réglages sur la bibliothèque de styles Homey.",
+    "nl": "Instellingenpagina afgestemd op de Homey-stijlbibliotheek.",
+    "no": "Justert innstillingssiden etter Homey-stilbiblioteket.",
+    "sv": "Inställningssidan anpassad till Homeys stilbibliotek."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -130,5 +130,5 @@
       "värmepump"
     ]
   },
-  "version": "24.0.1"
+  "version": "24.0.2"
 }

--- a/app.json
+++ b/app.json
@@ -131,5 +131,5 @@
       "värmepump"
     ]
   },
-  "version": "24.0.1"
+  "version": "24.0.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.0.1",
+  "version": "24.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.0.1",
+      "version": "24.0.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.0.1",
+  "version": "24.0.2",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
Style-library markup fix for the store build — promote this one (builds 92/93 carry the older layouts). The GitHub release will also be the live test of the refreshed HOMEY_PAT through publish.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)