### PR TITLE
feat: collapsible configuration, sorted devices, per-device opt-out

### DIFF
--- a/.homeycompose/locales/da.json
+++ b/.homeycompose/locales/da.json
@@ -24,6 +24,7 @@
       "true": "Ja"
     },
     "defaultSource": "Homey-vejr (standard)",
+    "disabledSource": "Juster ikke",
     "enabled": "Hold inden for 8 °C af udendørstemperaturen",
     "log": "Historik",
     "notFound": "Du skal først konfigurere dine enheder i MELCloud Homey-appen.\n\nØnsker du at installere den?",

--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -24,6 +24,7 @@
       "true": "Yes"
     },
     "defaultSource": "Homey weather (default)",
+    "disabledSource": "Do not adjust",
     "enabled": "Keep within 8 °C of the outdoor temperature",
     "log": "History",
     "notFound": "First, you need to set up your devices in the MELCloud Homey app.\n\nDo you want to install it?",

--- a/.homeycompose/locales/es.json
+++ b/.homeycompose/locales/es.json
@@ -24,6 +24,7 @@
       "true": "Sí"
     },
     "defaultSource": "Tiempo de Homey (predeterminado)",
+    "disabledSource": "No ajustar",
     "enabled": "Mantener dentro de los 8 °C de la temperatura exterior",
     "log": "Historial",
     "notFound": "Primero, debes configurar tus dispositivos en la aplicación Homey MELCloud.\n\n¿Deseas instalarla?",

--- a/.homeycompose/locales/fr.json
+++ b/.homeycompose/locales/fr.json
@@ -24,6 +24,7 @@
       "true": "Oui"
     },
     "defaultSource": "Météo Homey (par défaut)",
+    "disabledSource": "Ne pas activer",
     "enabled": "Maintenir à moins de 8 °C de la température extérieure",
     "log": "Historique",
     "notFound": "Vous devez d'abord configurer vos appareils dans l'appli Homey MELCloud.\n\nVoulez-vous l'installer ?",

--- a/.homeycompose/locales/nl.json
+++ b/.homeycompose/locales/nl.json
@@ -24,6 +24,7 @@
       "true": "Ja"
     },
     "defaultSource": "Homey-weer (standaard)",
+    "disabledSource": "Niet aanpassen",
     "enabled": "Blijf binnen 8 °C van de buitentemperatuur",
     "log": "Overzicht",
     "notFound": "Je moet eerst je apparaten instellen in de MELCloud Homey app.\n\nWil je deze installeren?",

--- a/.homeycompose/locales/no.json
+++ b/.homeycompose/locales/no.json
@@ -24,6 +24,7 @@
       "true": "Ja"
     },
     "defaultSource": "Homey-vær (standard)",
+    "disabledSource": "Ikke juster",
     "enabled": "Hold innenfor 8 °C av utetemperaturen",
     "log": "Historikk",
     "notFound": "Først må du sette opp enhetene dine i MELCloud Homey-appen.\n\nVil du installere den?",

--- a/.homeycompose/locales/sv.json
+++ b/.homeycompose/locales/sv.json
@@ -24,6 +24,7 @@
       "true": "Ja"
     },
     "defaultSource": "Homey-väder (standard)",
+    "disabledSource": "Justera inte",
     "enabled": "Håll inom 8 °C från utomhustemperaturen",
     "log": "Historik",
     "notFound": "Du behöver först konfigurera dina enheter i MELCloud Homey-appen.\n\nVill du installera den?",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,10 @@ to judge success.
 - The threshold (user comfort setpoint) is persisted per device id in
   the `thresholds` setting; reverting falls back to 0 °C if the stored
   entry disappeared.
-- Outdoor sources are per device (`outdoorSources` setting, null =
-  Homey weather); the legacy global `capabilityPath` is migrated to
-  every known AC device once, then unset.
+- Outdoor sources are per device (`outdoorSources` setting: null/absent
+  = Homey weather, `'none'` = the device is not adjusted at all); the
+  legacy global `capabilityPath` is migrated to every known AC device
+  once, then unset.
 - The Homey weather (home-screen temperature) is served by the LOCAL
   weather manager — `homey.api.get('/manager/weather/weather')`, covered
   by the app's `homey:manager:api` permission (homey-api does not wrap

--- a/api.mts
+++ b/api.mts
@@ -26,8 +26,8 @@ const api = {
     await app.autoAdjustCooling(body)
   },
   /**
-   * Lists the MELCloud AC devices with their configured outdoor source
-   * (`null` when they follow the Homey weather default).
+   * Lists the MELCloud AC devices, sorted by name, with their configured
+   * outdoor source (`null` when they follow the Homey weather default).
    * @param options - Homey API context.
    * @param options.homey - Homey instance carrying the app.
    * @returns One entry per AC device, with its configured source.
@@ -39,11 +39,13 @@ const api = {
       throw new NotFoundError()
     }
     const outdoorSources = app.homey.settings.get('outdoorSources') ?? {}
-    return app.melcloudDevices.map(({ id, name }) => ({
-      id,
-      name,
-      outdoorSource: outdoorSources[id] ?? null,
-    }))
+    return app.melcloudDevices
+      .map(({ id, name }) => ({
+        id,
+        name,
+        outdoorSource: outdoorSources[id] ?? null,
+      }))
+      .toSorted((device1, device2) => device1.name.localeCompare(device2.name))
   },
   /**
    * Reads the language configured on the Homey.

--- a/app.mts
+++ b/app.mts
@@ -15,6 +15,7 @@ import {
   type Names,
   type TemperatureListenerData,
   type TimestampedLog,
+  DISABLED_SOURCE,
   MEASURE_TEMPERATURE,
 } from './types.mts'
 
@@ -110,9 +111,11 @@ export default class MELCloudExtensionApp extends App {
       return
     }
     await Promise.all(
-      this.#melcloudDevices.map(async (device) =>
-        this.#listenToDevice(device, outdoorSources[device.id] ?? null),
-      ),
+      this.#melcloudDevices
+        .filter(({ id }) => (outdoorSources[id] ?? null) !== DISABLED_SOURCE)
+        .map(async (device) =>
+          this.#listenToDevice(device, outdoorSources[device.id] ?? null),
+        ),
     )
   }
 

--- a/locales/da.json
+++ b/locales/da.json
@@ -29,6 +29,7 @@
     "notFound": "Du skal først konfigurere dine enheder i MELCloud Homey-appen.\n\nØnsker du at installere den?",
     "refresh": "Genindlæs",
     "title": "Indstillinger for MELCloud-udvidelse",
-    "defaultSource": "Homey-vejr (standard)"
+    "defaultSource": "Homey-vejr (standard)",
+    "disabledSource": "Juster ikke"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,6 +29,7 @@
     "notFound": "First, you need to set up your devices in the MELCloud Homey app.\n\nDo you want to install it?",
     "refresh": "Refresh",
     "title": "MELCloud extension settings",
-    "defaultSource": "Homey weather (default)"
+    "defaultSource": "Homey weather (default)",
+    "disabledSource": "Do not adjust"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -29,6 +29,7 @@
     "notFound": "Primero, debes configurar tus dispositivos en la aplicación Homey MELCloud.\n\n¿Deseas instalarla?",
     "refresh": "Recargar",
     "title": "Configuración de la extensión para MELCloud",
-    "defaultSource": "Tiempo de Homey (predeterminado)"
+    "defaultSource": "Tiempo de Homey (predeterminado)",
+    "disabledSource": "No ajustar"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -29,6 +29,7 @@
     "notFound": "Vous devez d'abord configurer vos appareils dans l'appli Homey MELCloud.\n\nVoulez-vous l'installer ?",
     "refresh": "Rafraîchir",
     "title": "Paramètres de l'extension pour MELCloud",
-    "defaultSource": "Météo Homey (par défaut)"
+    "defaultSource": "Météo Homey (par défaut)",
+    "disabledSource": "Ne pas activer"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -29,6 +29,7 @@
     "notFound": "Je moet eerst je apparaten instellen in de MELCloud Homey app.\n\nWil je deze installeren?",
     "refresh": "Herladen",
     "title": "Instellingen van de MELCloud-extensie",
-    "defaultSource": "Homey-weer (standaard)"
+    "defaultSource": "Homey-weer (standaard)",
+    "disabledSource": "Niet aanpassen"
   }
 }

--- a/locales/no.json
+++ b/locales/no.json
@@ -29,6 +29,7 @@
     "notFound": "Først må du sette opp enhetene dine i MELCloud Homey-appen.\n\nVil du installere den?",
     "refresh": "Gjenta",
     "title": "Innstillinger for MELCloud-utvidelse",
-    "defaultSource": "Homey-vær (standard)"
+    "defaultSource": "Homey-vær (standard)",
+    "disabledSource": "Ikke juster"
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -29,6 +29,7 @@
     "notFound": "Du behöver först konfigurera dina enheter i MELCloud Homey-appen.\n\nVill du installera den?",
     "refresh": "Ladda om",
     "title": "Inställningar för MELCloud-tillägg",
-    "defaultSource": "Homey-väder (standard)"
+    "defaultSource": "Homey-väder (standard)",
+    "disabledSource": "Justera inte"
   }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -13,40 +13,42 @@
         <header class="homey-header">
             <h1 class="homey-title" data-i18n="settings.title">MELCloud extension settings</h1>
         </header>
-        <fieldset class="homey-form-fieldset">
-            <legend class="homey-form-legend" data-i18n="settings.autoAdjust"></legend>
-            <div class="homey-form-group">
-                <label
-                    class="homey-form-label"
-                    aria-label="Enabled"
-                    data-i18n="settings.enabled"
-                    for="enabled"
-                ></label>
-                <select id="enabled" class="homey-form-select">
-                    <option data-i18n="settings.boolean.false" value="false">No</option>
-                    <option data-i18n="settings.boolean.true" value="true">Yes</option>
-                </select>
-            </div>
-            <div id="sources"></div>
-            <div class="homey-form-group">
-                <button
-                    id="refresh"
-                    type="button"
-                    class="homey-button-secondary-shadow-full"
-                    aria-label="Refresh"
-                    data-i18n="settings.refresh"
-                ></button>
-            </div>
-            <div class="homey-form-group">
-                <button
-                    id="apply"
-                    type="button"
-                    class="homey-button-danger-shadow-full"
-                    aria-label="Apply"
-                    data-i18n="settings.apply"
-                ></button>
-            </div>
-        </fieldset>
+        <details id="configuration">
+            <summary class="homey-form-legend" data-i18n="settings.autoAdjust">Auto-adjust air conditioning temperature</summary>
+            <fieldset class="homey-form-fieldset">
+                <div class="homey-form-group">
+                    <label
+                        class="homey-form-label"
+                        aria-label="Enabled"
+                        data-i18n="settings.enabled"
+                        for="enabled"
+                    ></label>
+                    <select id="enabled" class="homey-form-select">
+                        <option data-i18n="settings.boolean.false" value="false">No</option>
+                        <option data-i18n="settings.boolean.true" value="true">Yes</option>
+                    </select>
+                </div>
+                <div id="sources"></div>
+                <div class="homey-form-group">
+                    <button
+                        id="refresh"
+                        type="button"
+                        class="homey-button-secondary-shadow-full"
+                        aria-label="Refresh"
+                        data-i18n="settings.refresh"
+                    ></button>
+                </div>
+                <div class="homey-form-group">
+                    <button
+                        id="apply"
+                        type="button"
+                        class="homey-button-danger-shadow-full"
+                        aria-label="Apply"
+                        data-i18n="settings.apply"
+                    ></button>
+                </div>
+            </fieldset>
+        </details>
         <fieldset class="homey-form-fieldset">
             <legend class="homey-form-legend" data-i18n="settings.log"></legend>
             <table class="homey-form-group" aria-label="Log">

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1,13 +1,14 @@
 import type Homey from 'homey/lib/HomeySettings'
 import { Temporal } from 'temporal-polyfill'
 
-import type {
-  AdjustableDevice,
-  HomeySettings,
-  OutdoorSources,
-  TemperatureListenerData,
-  TemperatureSensor,
-  TimestampedLog,
+import {
+  type AdjustableDevice,
+  type HomeySettings,
+  type OutdoorSources,
+  type TemperatureListenerData,
+  type TemperatureSensor,
+  type TimestampedLog,
+  DISABLED_SOURCE,
 } from '../types.mts'
 
 const LOG_RETENTION_DAYS = 6
@@ -273,7 +274,10 @@ const createSourceSelect = (
   const select = document.createElement('select')
   select.classList.add('homey-form-select')
   select.id = `source-${device.id}`
-  select.append(new Option(homey.__('settings.defaultSource'), ''))
+  select.append(
+    new Option(homey.__('settings.disabledSource'), DISABLED_SOURCE),
+    new Option(homey.__('settings.defaultSource'), ''),
+  )
   for (const { capabilityName, capabilityPath } of sensors) {
     select.append(new Option(capabilityName, capabilityPath))
   }

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -26,3 +26,8 @@
 .log-message-listened {
   color: #0047ab;
 }
+
+summary {
+  cursor: pointer;
+  margin-block-end: 1em;
+}

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -113,24 +113,25 @@ describe('api', () => {
       ])
     })
 
-    it('should map the devices to their configured source', () => {
+    it('should map the devices to their configured source, sorted by name', () => {
       const { homey } = createHomeyContext({
         melcloudDevices: [classicDevice.device, homeDevice.device],
         settings: {
           outdoorSources: {
             'classic-1': 'classic-1:measure_temperature.outdoor',
+            'home-1': 'none',
           },
         },
         temperatureSensors: [],
       })
 
       expect(api.getAdjustableDevices({ homey })).toStrictEqual([
+        { id: 'home-1', name: 'Bedroom', outdoorSource: 'none' },
         {
           id: 'classic-1',
           name: 'Living room',
           outdoorSource: 'classic-1:measure_temperature.outdoor',
         },
-        { id: 'home-1', name: 'Bedroom', outdoorSource: null },
       ])
     })
   })

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -213,6 +213,23 @@ describe(MELCloudExtensionApp, () => {
     expect(homeDevice.capabilityInstances.has('target_temperature')).toBe(true)
   })
 
+  it('should leave a device opted out with the disabled source alone', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    classicDevice.values.thermostat_mode = 'cool'
+    homeDevice.values.thermostat_mode = 'cool'
+    await createHarness([classicDevice, homeDevice], {
+      settings: {
+        isEnabled: true,
+        outdoorSources: { 'classic-1': 'none' },
+      },
+    })
+
+    await advancePastInit()
+
+    expect(classicDevice.capabilityInstances.size).toBe(0)
+    expect(homeDevice.capabilityInstances.has('target_temperature')).toBe(true)
+  })
+
   it('should persist the settings without listening when disabled', async () => {
     const { classicDevice } = createDevices()
     const { mockHomey } = await createHarness([classicDevice])

--- a/types.mts
+++ b/types.mts
@@ -34,8 +34,11 @@ export interface Names {
   readonly thermostatMode: string
 }
 
-// Per-device outdoor feed: a "deviceId:capabilityId" path, or null for
-// the Homey weather default.
+// Explicit per-device opt-out: the device is not adjusted at all
+export const DISABLED_SOURCE = 'none'
+
+// Per-device outdoor feed: a "deviceId:capabilityId" path, DISABLED_SOURCE
+// to leave the device alone, or null for the Homey weather default.
 export type OutdoorSources = Partial<Record<string, string | null>>
 
 export interface TemperatureListenerData {


### PR DESCRIPTION
- The whole configuration block folds into a native `<details>`/`<summary>` (Homey-form legend styling, collapsed by default) — the history is visible without scrolling past 18 selects.
- `getAdjustableDevices` returns the devices sorted by name.
- New per-device option **Do not adjust** (sentinel `'none'`, first in the list, before the Homey-weather default): the device gets no listener at all. Null/absent still means the weather default — 24.0.x settings unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)