### PR TITLE
chore: release Homey app v24.2.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -103,5 +103,14 @@
     "nl": "Instellingen: inklapbare configuratie, apparaten alfabetisch gesorteerd en een nieuwe optie om een apparaat niet aan te passen.",
     "no": "Innstillinger: sammenleggbar konfigurasjon, enheter sortert alfabetisk og nytt valg for å ikke justere en enhet.",
     "sv": "Inställningar: hopfällbar konfiguration, enheter sorterade i bokstavsordning och nytt alternativ för att inte justera en enhet."
+  },
+  "24.2.0": {
+    "da": "Indstillinger: autofuldførelsesfelt over hver kildevælger.",
+    "en": "Settings: autocomplete field above each source selector.",
+    "es": "Ajustes: campo de autocompletado sobre cada selector de fuente.",
+    "fr": "Réglages : champ d'autocomplétion au-dessus de chaque sélecteur de source.",
+    "nl": "Instellingen: autoaanvulveld boven elke bronkiezer.",
+    "no": "Innstillinger: autofullføringsfelt over hver kildevelger.",
+    "sv": "Inställningar: autokompletteringsfält ovanför varje källväljare."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -130,5 +130,5 @@
       "värmepump"
     ]
   },
-  "version": "24.1.0"
+  "version": "24.2.0"
 }

--- a/app.json
+++ b/app.json
@@ -131,5 +131,5 @@
       "värmepump"
     ]
   },
-  "version": "24.1.0"
+  "version": "24.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.1.0",
+  "version": "24.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.1.0",
+      "version": "24.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.1.0",
+  "version": "24.2.0",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
Autocomplete search above the source selectors — feature release (minor bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)