### PR TITLE
feat: enabled-aware configuration fold + com.melcloud button pair

### DIFF
--- a/.homeycompose/locales/da.json
+++ b/.homeycompose/locales/da.json
@@ -17,7 +17,6 @@
     "thermostatMode": "tilstanden"
   },
   "settings": {
-    "apply": "Anvend på alle luft-til-luft enheder",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
       "false": "Nej",
@@ -30,6 +29,7 @@
     "notFound": "Du skal først konfigurere dine enheder i MELCloud Homey-appen.\n\nØnsker du at installere den?",
     "refresh": "Genindlæs",
     "searchSource": "Søg efter en kilde …",
-    "title": "Indstillinger for MELCloud-udvidelse"
+    "title": "Indstillinger for MELCloud-udvidelse",
+    "update": "Opdater"
   }
 }

--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -17,7 +17,6 @@
     "thermostatMode": "the mode"
   },
   "settings": {
-    "apply": "Apply to all air-to-air devices",
     "autoAdjust": "Auto-adjust air conditioning temperature",
     "boolean": {
       "false": "No",
@@ -30,6 +29,7 @@
     "notFound": "First, you need to set up your devices in the MELCloud Homey app.\n\nDo you want to install it?",
     "refresh": "Refresh",
     "searchSource": "Search for a source…",
-    "title": "MELCloud extension settings"
+    "title": "MELCloud extension settings",
+    "update": "Update"
   }
 }

--- a/.homeycompose/locales/es.json
+++ b/.homeycompose/locales/es.json
@@ -17,7 +17,6 @@
     "thermostatMode": "el modo"
   },
   "settings": {
-    "apply": "Aplicar a todos los dispositivos aire-aire",
     "autoAdjust": "Autoajustar la temperatura del aire acondicionado",
     "boolean": {
       "false": "No",
@@ -30,6 +29,7 @@
     "notFound": "Primero, debes configurar tus dispositivos en la aplicación Homey MELCloud.\n\n¿Deseas instalarla?",
     "refresh": "Recargar",
     "searchSource": "Buscar una fuente…",
-    "title": "Configuración de la extensión para MELCloud"
+    "title": "Configuración de la extensión para MELCloud",
+    "update": "Actualizar"
   }
 }

--- a/.homeycompose/locales/fr.json
+++ b/.homeycompose/locales/fr.json
@@ -17,7 +17,6 @@
     "thermostatMode": "le mode"
   },
   "settings": {
-    "apply": "Appliquer à tous les appareils air-air",
     "autoAdjust": "Auto-ajuster la température de la climatisation",
     "boolean": {
       "false": "Non",
@@ -30,6 +29,7 @@
     "notFound": "Vous devez d'abord configurer vos appareils dans l'appli Homey MELCloud.\n\nVoulez-vous l'installer ?",
     "refresh": "Rafraîchir",
     "searchSource": "Rechercher une source…",
-    "title": "Paramètres de l'extension pour MELCloud"
+    "title": "Paramètres de l'extension pour MELCloud",
+    "update": "Mettre à jour"
   }
 }

--- a/.homeycompose/locales/nl.json
+++ b/.homeycompose/locales/nl.json
@@ -17,7 +17,6 @@
     "thermostatMode": "de modus"
   },
   "settings": {
-    "apply": "Toepassen op alle lucht-lucht apparaten",
     "autoAdjust": "Auto-afstellen airco-temperatuur",
     "boolean": {
       "false": "Nee",
@@ -30,6 +29,7 @@
     "notFound": "Je moet eerst je apparaten instellen in de MELCloud Homey app.\n\nWil je deze installeren?",
     "refresh": "Herladen",
     "searchSource": "Zoek een bron…",
-    "title": "Instellingen van de MELCloud-extensie"
+    "title": "Instellingen van de MELCloud-extensie",
+    "update": "Updaten"
   }
 }

--- a/.homeycompose/locales/no.json
+++ b/.homeycompose/locales/no.json
@@ -17,7 +17,6 @@
     "thermostatMode": "modus"
   },
   "settings": {
-    "apply": "Bruk på alle luft-til-luft enheter",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
       "false": "Nei",
@@ -30,6 +29,7 @@
     "notFound": "Først må du sette opp enhetene dine i MELCloud Homey-appen.\n\nVil du installere den?",
     "refresh": "Gjenta",
     "searchSource": "Søk etter en kilde …",
-    "title": "Innstillinger for MELCloud-utvidelse"
+    "title": "Innstillinger for MELCloud-utvidelse",
+    "update": "Oppdater"
   }
 }

--- a/.homeycompose/locales/sv.json
+++ b/.homeycompose/locales/sv.json
@@ -17,7 +17,6 @@
     "thermostatMode": "läget"
   },
   "settings": {
-    "apply": "Tillämpa på alla luft-till-luft enheter",
     "autoAdjust": "Autojustera luftkonditioneringstemperaturen",
     "boolean": {
       "false": "Nej",
@@ -30,6 +29,7 @@
     "notFound": "Du behöver först konfigurera dina enheter i MELCloud Homey-appen.\n\nVill du installera den?",
     "refresh": "Ladda om",
     "searchSource": "Sök efter en källa …",
-    "title": "Inställningar för MELCloud-tillägg"
+    "title": "Inställningar för MELCloud-tillägg",
+    "update": "Uppdatera"
   }
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -31,6 +31,7 @@
     "title": "Indstillinger for MELCloud-udvidelse",
     "defaultSource": "Homey-vejr (standard)",
     "disabledSource": "Juster ikke",
-    "searchSource": "Søg efter en kilde …"
+    "searchSource": "Søg efter en kilde …",
+    "update": "Opdater"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -31,6 +31,7 @@
     "title": "MELCloud extension settings",
     "defaultSource": "Homey weather (default)",
     "disabledSource": "Do not adjust",
-    "searchSource": "Search for a source…"
+    "searchSource": "Search for a source…",
+    "update": "Update"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -31,6 +31,7 @@
     "title": "Configuración de la extensión para MELCloud",
     "defaultSource": "Tiempo de Homey (predeterminado)",
     "disabledSource": "No ajustar",
-    "searchSource": "Buscar una fuente…"
+    "searchSource": "Buscar una fuente…",
+    "update": "Actualizar"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -31,6 +31,7 @@
     "title": "Paramètres de l'extension pour MELCloud",
     "defaultSource": "Météo Homey (par défaut)",
     "disabledSource": "Ne pas activer",
-    "searchSource": "Rechercher une source…"
+    "searchSource": "Rechercher une source…",
+    "update": "Mettre à jour"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -31,6 +31,7 @@
     "title": "Instellingen van de MELCloud-extensie",
     "defaultSource": "Homey-weer (standaard)",
     "disabledSource": "Niet aanpassen",
-    "searchSource": "Zoek een bron…"
+    "searchSource": "Zoek een bron…",
+    "update": "Updaten"
   }
 }

--- a/locales/no.json
+++ b/locales/no.json
@@ -31,6 +31,7 @@
     "title": "Innstillinger for MELCloud-utvidelse",
     "defaultSource": "Homey-vær (standard)",
     "disabledSource": "Ikke juster",
-    "searchSource": "Søk etter en kilde …"
+    "searchSource": "Søk etter en kilde …",
+    "update": "Oppdater"
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -31,6 +31,7 @@
     "title": "Inställningar för MELCloud-tillägg",
     "defaultSource": "Homey-väder (standard)",
     "disabledSource": "Justera inte",
-    "searchSource": "Sök efter en källa …"
+    "searchSource": "Sök efter en källa …",
+    "update": "Uppdatera"
   }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -29,23 +29,21 @@
                     </select>
                 </div>
                 <div id="sources"></div>
-                <div class="homey-form-group">
+                <div class="container">
                     <button
                         id="refresh"
                         type="button"
-                        class="homey-button-secondary-shadow-full"
+                        class="homey-button-secondary-shadow"
                         aria-label="Refresh"
                         data-i18n="settings.refresh"
-                    ></button>
-                </div>
-                <div class="homey-form-group">
+                    >Refresh</button>
                     <button
                         id="apply"
                         type="button"
-                        class="homey-button-danger-shadow-full"
-                        aria-label="Apply"
-                        data-i18n="settings.apply"
-                    ></button>
+                        class="homey-button-danger-shadow"
+                        aria-label="Update"
+                        data-i18n="settings.update"
+                    >Update</button>
                 </div>
             </fieldset>
         </details>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -100,7 +100,11 @@ const getDivElement = (id: string): HTMLDivElement =>
 const getTableSectionElement = (id: string): HTMLTableSectionElement =>
   getElement(id, HTMLTableSectionElement, 'table section')
 
+const getDetailsElement = (id: string): HTMLDetailsElement =>
+  getElement(id, HTMLDetailsElement, 'details')
+
 const applyElement = getButtonElement('apply')
+const configurationElement = getDetailsElement('configuration')
 const refreshElement = getButtonElement('refresh')
 const enabledElement = getSelectElement('enabled')
 const logsElement = getTableSectionElement('logs')
@@ -230,6 +234,9 @@ const displayRetainedLogs = (logs: readonly TimestampedLog[]): void => {
 const handleSettings = (settings: HomeySettings): void => {
   displayRetainedLogs(settings.lastLogs ?? [])
   enabledElement.value = String(settings.isEnabled === true)
+  // Not adjusting yet: surface the configuration; already running:
+  // fold it away so the history is one glance away.
+  configurationElement.open = settings.isEnabled !== true
 }
 
 const fetchLanguage = async (homey: Homey): Promise<void> => {

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -35,3 +35,10 @@ summary {
 .source-search {
   margin-block-end: 0.5em;
 }
+
+/* Two-column grid for button pairs */
+.container {
+  display: grid;
+  gap: var(--homey-su-2);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}


### PR DESCRIPTION
- The `<details>` now follows the enabled state at load: **off → expanded** (setup in front), **on → collapsed** (logs first). No official autocomplete component exists in the Homey Style Library (checked the docs — inputs/selects/radios/checkboxes/buttons only), so the `homey-form-input` + native datalist stays.
- Buttons harmonized with com.melcloud: Refresh/Update side by side (`.container` two-column grid with the `--homey-su-2` token), `homey-button-secondary-shadow` / `homey-button-danger-shadow`, `settings.update` labels copied from com.melcloud's locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)