### PR TITLE
fix: scrollable dropdown with the native-menu presentation

### DIFF
--- a/settings/index.mts
+++ b/settings/index.mts
@@ -347,29 +347,44 @@ const displaySelection = (input: HTMLInputElement, deviceId: string): void => {
   input.value = sourceNamesByValue.get(current) ?? ''
 }
 
+interface RenderOptionsParams {
+  readonly filter: string
+  readonly selectedValue: string
+  readonly onPick: (option: SourceOption) => void
+}
+
+const createOptionItem = (
+  option: SourceOption,
+  { onPick, selectedValue }: RenderOptionsParams,
+): HTMLLIElement => {
+  const item = document.createElement('li')
+  item.classList.add('combobox-option')
+  item.classList.toggle('is-selected', option.value === selectedValue)
+  item.setAttribute('role', 'option')
+  item.setAttribute(
+    'aria-selected',
+    option.value === selectedValue ? 'true' : 'false',
+  )
+  item.textContent = option.name
+  // pointerdown beats the input blur, so picking commits first
+  item.addEventListener('pointerdown', (event) => {
+    event.preventDefault()
+    onPick(option)
+  })
+  return item
+}
+
 const renderOptions = (
   list: HTMLUListElement,
-  filter: string,
-  onPick: (option: SourceOption) => void,
+  params: RenderOptionsParams,
 ): void => {
-  const needle = filter.trim().toLowerCase()
+  const needle = params.filter.trim().toLowerCase()
   const matches =
     needle === '' ? sourceOptions : (
       sourceOptions.filter(({ name }) => name.toLowerCase().includes(needle))
     )
   list.replaceChildren(
-    ...matches.map((option) => {
-      const item = document.createElement('li')
-      item.classList.add('combobox-option')
-      item.setAttribute('role', 'option')
-      item.textContent = option.name
-      // pointerdown beats the input blur, so picking commits first
-      item.addEventListener('pointerdown', (event) => {
-        event.preventDefault()
-        onPick(option)
-      })
-      return item
-    }),
+    ...matches.map((option) => createOptionItem(option, params)),
   )
 }
 
@@ -398,7 +413,11 @@ const openList = (
   onPick: (option: SourceOption) => void,
 ): void => {
   closeOpenCombobox()
-  renderOptions(parts.list, '', onPick)
+  renderOptions(parts.list, {
+    filter: '',
+    onPick,
+    selectedValue: sourceSelections.get(deviceId) ?? '',
+  })
   parts.list.hidden = false
   parts.input.setAttribute('aria-expanded', 'true')
   parts.input.select()
@@ -425,7 +444,11 @@ const wireCombobox = (parts: ComboboxParts, device: AdjustableDevice): void => {
     if (list.hidden === true) {
       openList(parts, device.id, pick)
     }
-    renderOptions(list, input.value, pick)
+    renderOptions(list, {
+      filter: input.value,
+      onPick: pick,
+      selectedValue: sourceSelections.get(device.id) ?? '',
+    })
   })
 }
 

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -65,27 +65,37 @@ summary {
   inline-size: 100%;
 }
 
+/* Native-menu look (the platform select popup): soft shadow, large
+   radius, a checkmark gutter — `overflow: auto` because the logical
+   overflow-block is not supported by the phone webviews */
 .combobox-list {
   background: #fff;
-  border: 1px solid #e0e0e0;
-  border-radius: 0.5em;
-  box-shadow: 0 0.25em 0.75em rgb(0 0 0 / 15%);
+  border-radius: 1em;
+  box-shadow: 0 0.5em 2em rgb(0 0 0 / 20%);
   inset-block-start: calc(100% + 0.25em);
   inset-inline: 0;
   list-style: none;
   margin: 0;
   max-block-size: 16em;
-  overflow-block: auto;
-  padding: 0.25em 0;
+  overflow: auto;
+  padding: 0.5em 0;
   position: absolute;
   z-index: 10;
 }
 
 .combobox-option {
   cursor: pointer;
-  padding: 0.6em 1em;
+  padding: 0.75em 1em;
+  padding-inline-start: 2.4em;
+  position: relative;
 }
 
 .combobox-option:hover {
   background: #f2f2f2;
+}
+
+.combobox-option.is-selected::before {
+  content: '✓';
+  inset-inline-start: 1em;
+  position: absolute;
 }


### PR DESCRIPTION
Two follow-ups from the phone screenshot:
- **Scroll**: `overflow-block` (forced by css/prefer-logical-properties) is unsupported by WKWebView — the list could not scroll. `overflow: auto` is axis-agnostic, so no logical/physical debate and universal support.
- **Presentation**: the panel now matches the native select menu shown in the screenshot — 1em radius, borderless soft shadow, roomier options, and a ✓ in the leading gutter on the currently selected option (with `aria-selected`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)