### PR TITLE
fix: select-like touch behavior + cache-busted settings assets

### DIFF
--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,6 +1,9 @@
 // Bundles the settings page into a single self-contained ES module served
 // statically by Homey, inlining npm dependencies (temporal-polyfill) so the
 // webview works offline with versions pinned by the lockfile.
+import { createHash } from 'node:crypto'
+import { readFile, writeFile } from 'node:fs/promises'
+
 import { build } from 'esbuild'
 
 await build({
@@ -13,3 +16,26 @@ await build({
   outfile: 'settings/index.mjs',
   target: ['es2020'],
 })
+
+// Cache-bust the static references: the phone webviews cache settings
+// assets across app versions, so a content hash per file forces a refetch
+// exactly when a file changes.
+const hashOf = async (path) => {
+  const content = await readFile(path)
+  return createHash('sha256').update(content).digest('hex').slice(0, 8)
+}
+
+const htmlPath = 'settings/index.html'
+const html = await readFile(htmlPath, 'utf8')
+const stamped = html
+  .replace(
+    /index\.mjs(?:\?v=[0-9a-f]+)?/u,
+    `index.mjs?v=${await hashOf('settings/index.mjs')}`,
+  )
+  .replace(
+    /styles\.css(?:\?v=[0-9a-f]+)?/u,
+    `styles.css?v=${await hashOf('settings/styles.css')}`,
+  )
+if (stamped !== html) {
+  await writeFile(htmlPath, stamped)
+}

--- a/settings/index.html
+++ b/settings/index.html
@@ -4,9 +4,9 @@
         <meta charset="utf-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Extension Settings</title>
-        <link href="styles.css" rel="stylesheet">
+        <link href="styles.css?v=eb9102d0" rel="stylesheet">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs"></script>
+        <script type="module" src="index.mjs?v=89d73afd"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -333,6 +333,9 @@ const createSourceInputElement = (
 ): HTMLInputElement => {
   const input = document.createElement('input')
   input.type = 'text'
+  // Select-like on touch devices: the first tap drops the list without
+  // summoning the keyboard; a second tap switches to typing mode.
+  input.inputMode = 'none'
   input.classList.add('homey-form-input', 'combobox-input')
   input.id = `source-${device.id}`
   input.setAttribute('role', 'combobox')
@@ -404,6 +407,7 @@ interface ComboboxParts {
 const closeList = ({ input, list }: ComboboxParts, deviceId: string): void => {
   list.hidden = true
   input.setAttribute('aria-expanded', 'false')
+  input.inputMode = 'none'
   displaySelection(input, deviceId)
 }
 
@@ -420,7 +424,6 @@ const openList = (
   })
   parts.list.hidden = false
   parts.input.setAttribute('aria-expanded', 'true')
-  parts.input.select()
   openCombobox.close = (): void => {
     closeList(parts, deviceId)
   }
@@ -434,10 +437,17 @@ const wireCombobox = (parts: ComboboxParts, device: AdjustableDevice): void => {
     closeOpenCombobox()
     input.blur()
   }
-  // Clicking anywhere in the field drops the FULL list, select-style
+  // Clicking anywhere in the field drops the FULL list, select-style;
+  // clicking again summons the keyboard to filter by typing
   input.addEventListener('click', () => {
     if (list.hidden === true) {
       openList(parts, device.id, pick)
+      return
+    }
+    if (input.inputMode === 'none') {
+      input.inputMode = 'text'
+      input.blur()
+      input.focus()
     }
   })
   input.addEventListener('input', () => {


### PR DESCRIPTION
Two findings from the phone screenshots:
- **The webview caches settings statics across app versions** (the Homey serves the new files — verified by fetching them off the device — but the phone kept rendering the old ones until a force-quit). `scripts/bundle.mjs` now stamps `index.html`'s asset references with 8-char content hashes: a refetch happens exactly when a file changes.
- **Select-like touch UX**: the first tap opens the list with NO virtual keyboard (`inputmode=none`) and without the iOS selection handles (no more `select()`); tapping the focused field again switches to typing mode for filtering. Hardware keyboards filter regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)