### PR TITLE
fix: touch-scrollable source list + inherited typography

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -4,9 +4,9 @@
         <meta charset="utf-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Extension Settings</title>
-        <link href="styles.css?v=eb9102d0" rel="stylesheet">
+        <link href="styles.css?v=57751eb7" rel="stylesheet">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs?v=89d73afd"></script>
+        <script type="module" src="index.mjs?v=3f9437bd"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -369,9 +369,8 @@ const createOptionItem = (
     option.value === selectedValue ? 'true' : 'false',
   )
   item.textContent = option.name
-  // pointerdown beats the input blur, so picking commits first
-  item.addEventListener('pointerdown', (event) => {
-    event.preventDefault()
+  // click, not pointerdown: a touch drag must scroll the list, not pick
+  item.addEventListener('click', () => {
     onPick(option)
   })
   return item
@@ -424,6 +423,7 @@ const openList = (
   })
   parts.list.hidden = false
   parts.input.setAttribute('aria-expanded', 'true')
+  parts.list.querySelector('.is-selected')?.scrollIntoView({ block: 'nearest' })
   openCombobox.close = (): void => {
     closeList(parts, deviceId)
   }

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -62,6 +62,7 @@ summary {
 }
 
 .combobox-input {
+  font: inherit;
   inline-size: 100%;
 }
 
@@ -76,6 +77,7 @@ summary {
   inset-inline: 0;
   list-style: none;
   margin: 0;
+  font: inherit;
   max-block-size: 16em;
   overflow: auto;
   padding: 0.5em 0;


### PR DESCRIPTION
- **Scroll**: picking happened on `pointerdown` (a leftover guard against a blur race that no longer exists) — the first touch of any scroll gesture committed an option, so the list could never scroll. Picking now happens on `click`; touch drags scroll natively.
- **Typography**: form controls don't inherit the page font — `font: inherit` on the field and the panel fixes the letter-height mismatch seen on both platforms.
- Opening the list scrolls the ✓ option into view, select-style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)