### PR TITLE
fix: stroke checkmark, full-state refresh, enable above buttons

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -4,9 +4,9 @@
         <meta charset="utf-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Extension Settings</title>
-        <link href="styles.css?v=57751eb7" rel="stylesheet">
+        <link href="styles.css?v=7bf682fa" rel="stylesheet">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs?v=01e91646"></script>
+        <script type="module" src="index.mjs?v=6ccb92df"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>
@@ -20,6 +20,18 @@
             </fieldset>
         </details>
         <fieldset class="homey-form-fieldset">
+            <div class="homey-form-group">
+                <label
+                    class="homey-form-label"
+                    aria-label="Enabled"
+                    data-i18n="settings.enabled"
+                    for="enabled"
+                ></label>
+                <select id="enabled" class="homey-form-select">
+                    <option data-i18n="settings.boolean.false" value="false">No</option>
+                    <option data-i18n="settings.boolean.true" value="true">Yes</option>
+                </select>
+            </div>
             <div class="container">
                 <button
                     id="refresh"
@@ -35,18 +47,6 @@
                     aria-label="Update"
                     data-i18n="settings.update"
                 >Update</button>
-            </div>
-            <div class="homey-form-group">
-                <label
-                    class="homey-form-label"
-                    aria-label="Enabled"
-                    data-i18n="settings.enabled"
-                    for="enabled"
-                ></label>
-                <select id="enabled" class="homey-form-select">
-                    <option data-i18n="settings.boolean.false" value="false">No</option>
-                    <option data-i18n="settings.boolean.true" value="true">Yes</option>
-                </select>
             </div>
         </fieldset>
         <fieldset class="homey-form-fieldset">

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -253,9 +253,6 @@ const displayRetainedLogs = (logs: readonly TimestampedLog[]): void => {
 const handleSettings = (settings: HomeySettings): void => {
   displayRetainedLogs(settings.lastLogs ?? [])
   enabledElement.value = String(settings.isEnabled === true)
-  // Not adjusting yet: surface the configuration; already running:
-  // fold it away so the history is one glance away.
-  configurationElement.open = settings.isEnabled !== true
 }
 
 const fetchLanguage = async (homey: Homey): Promise<void> => {
@@ -617,9 +614,16 @@ const autoAdjustCooling = async (homey: Homey): Promise<void> =>
     }
   })
 
+// Refresh restores every value to the last saved state (the stored
+// enable flag and per-device sources) without touching the fold
+const refreshAll = async (homey: Homey): Promise<void> => {
+  await populateSources(homey)
+  await fetchHomeySettings(homey)
+}
+
 const addEventListeners = (homey: Homey): void => {
   refreshElement.addEventListener('click', () => {
-    fireAndForget(fetchHomeySettings(homey))
+    fireAndForget(refreshAll(homey))
   })
   applyElement.addEventListener('click', () => {
     fireAndForget(autoAdjustCooling(homey))
@@ -635,6 +639,10 @@ const onHomeyReady = async (homey: Homey): Promise<void> => {
   }
   await populateSources(homey)
   await fetchHomeySettings(homey)
+  // Not adjusting yet: surface the configuration; already running:
+  // fold it away so the history is one glance away. Initial load only —
+  // a refresh must not undo a manual fold or unfold.
+  configurationElement.open = enabledElement.value === 'false'
   addEventListeners(homey)
   homey.ready()
 }

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -96,8 +96,16 @@ summary {
   background: #f2f2f2;
 }
 
+/* Thin stroke checkmark, same pen as the field chevron */
 .combobox-option.is-selected::before {
-  content: '✓';
+  block-size: 0.55em;
+  border-block-end: 0.15em solid currentColor;
+  border-inline-end: 0.15em solid currentColor;
+  content: '';
+  inline-size: 0.3em;
+  inset-block-start: 50%;
   inset-inline-start: 1em;
   position: absolute;
+  rotate: 45deg;
+  translate: 0 -65%;
 }


### PR DESCRIPTION
- The ✓ glyph is replaced by a CSS-drawn thin-stroke checkmark — same pen as the field chevron, matching the platform select menu.
- **Refresh** reloads the whole saved state (stored per-device sources AND the enable flag — unsaved edits are discarded) and never touches the fold anymore: the open-when-disabled rule now applies to the initial load only.
- Always-visible block order fixed: the enable field first, the Refresh/Update pair below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)