### PR TITLE
chore: release Homey app v24.7.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -256,5 +256,20 @@
     "pl": "Przewijanie listy nie wybiera już przypadkowo opcji.",
     "ru": "Прокрутка списка больше не выбирает пункт случайно.",
     "sv": "Att rulla i listan väljer inte längre ett alternativ av misstag."
+  },
+  "24.7.0": {
+    "ar": "تم تجميع الإعدادات حسب المبنى، وأعيد تنظيم الصفحة مع السجل في الأعلى، وأصبحت الطوابع الزمنية نسبية.",
+    "da": "Indstillinger grupperet efter bygning, siden er omorganiseret med historikken øverst og relative tidsstempler.",
+    "de": "Einstellungen nach Gebäude gruppiert, Seite mit dem Verlauf zuoberst neu geordnet und relative Zeitangaben.",
+    "en": "Settings are now grouped by building, the page starts with the history, and log timestamps are relative.",
+    "es": "Ajustes agrupados por edificio, página reorganizada con el historial arriba y marcas de tiempo relativas.",
+    "fr": "Réglages regroupés par bâtiment, page réorganisée avec l'historique en tête et horodatages relatifs.",
+    "it": "Impostazioni raggruppate per edificio, pagina riorganizzata con la cronologia in alto e orari relativi.",
+    "ko": "설정이 건물별로 그룹화되고 페이지 상단에 기록이 표시되며 타임스탬프가 상대 시간으로 표시됩니다.",
+    "nl": "Instellingen gegroepeerd per gebouw, pagina herschikt met de geschiedenis bovenaan en relatieve tijdstempels.",
+    "no": "Innstillinger gruppert etter bygning, siden er omorganisert med historikken øverst og relative tidsstempler.",
+    "pl": "Ustawienia pogrupowane według budynku, strona z historią na górze i względnymi znacznikami czasu.",
+    "ru": "Настройки сгруппированы по зданиям, страница начинается с истории, отметки времени стали относительными.",
+    "sv": "Inställningar grupperade per byggnad, sidan omorganiserad med historiken överst och relativa tidsstämplar."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -190,5 +190,5 @@
       "värmepump"
     ]
   },
-  "version": "24.6.2"
+  "version": "24.7.0"
 }

--- a/app.json
+++ b/app.json
@@ -191,5 +191,5 @@
       "värmepump"
     ]
   },
-  "version": "24.6.2"
+  "version": "24.7.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.6.2",
+  "version": "24.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.6.2",
+      "version": "24.7.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.6.2",
+  "version": "24.7.0",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/settings/index.html
+++ b/settings/index.html
@@ -6,7 +6,7 @@
         <title>MELCloud Extension Settings</title>
         <link href="styles.css?v=12811196" rel="stylesheet">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs?v=2814290c"></script>
+        <script type="module" src="index.mjs?v=44b3ed39"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>
@@ -43,9 +43,12 @@
         </fieldset>
         <fieldset class="homey-form-fieldset">
             <legend class="homey-form-legend" data-i18n="settings.log"></legend>
-            <table class="homey-form-group" aria-label="Log">
-                <tbody id="logs"></tbody>
-            </table>
+            <div
+                id="logs"
+                class="homey-form-group"
+                aria-label="Log"
+                role="log"
+            ></div>
         </fieldset>
         <fieldset class="homey-form-fieldset">
             <legend class="homey-form-legend" data-i18n="settings.configuration">Configuration</legend>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -98,15 +98,12 @@ const getSelectElement = (id: string): HTMLSelectElement =>
 const getDivElement = (id: string): HTMLDivElement =>
   getElement(id, HTMLDivElement, 'div')
 
-const getTableSectionElement = (id: string): HTMLTableSectionElement =>
-  getElement(id, HTMLTableSectionElement, 'table section')
-
 const applyElement = getButtonElement('apply')
 const emptyElement = getDivElement('empty_state')
 const installElement = getButtonElement('install')
 const refreshElement = getButtonElement('refresh')
 const enabledElement = getSelectElement('enabled')
-const logsElement = getTableSectionElement('logs')
+const logsElement = getDivElement('logs')
 const sourcesElement = getDivElement('sources')
 
 interface SourceOption {
@@ -177,8 +174,11 @@ const setButtonsBusy = (areBusy: boolean): void => {
 
 const withBusyButtons = async (action: () => Promise<void>): Promise<void> => {
   setButtonsBusy(true)
-  await action()
-  setButtonsBusy(false)
+  try {
+    await action()
+  } finally {
+    setButtonsBusy(false)
+  }
 }
 
 // The document language is the display locale: `fetchLanguage` overwrites


### PR DESCRIPTION
Per-building outdoor sources and the reorganized settings page (#1179) — changelog in 13 locales, version bump in compose, package.json and lockfile.

Also folds in the two Copilot follow-ups posted on #1179 after its final push:
- `withBusyButtons` now releases the buttons in a `finally`, so a rejected request can no longer leave them permanently greyed out.
- The log list is a plain `<div role="log">` instead of `<div>`s inserted into a `<tbody>` (invalid table content model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)