### PR TITLE
Settings follow building renames: device groups re-read on demand

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -271,5 +271,20 @@
     "pl": "Ustawienia pogrupowane według budynku, strona z historią na górze i względnymi znacznikami czasu.",
     "ru": "Настройки сгруппированы по зданиям, страница начинается с истории, отметки времени стали относительными.",
     "sv": "Inställningar grupperade per byggnad, sidan omorganiserad med historiken överst och relativa tidsstämplar."
+  },
+  "24.7.1": {
+    "ar": "تتبع الإعدادات الآن إعادة تسمية مباني MELCloud عند التحديث.",
+    "da": "Indstillingerne følger nu omdøbning af MELCloud-bygninger ved opdatering.",
+    "de": "Die Einstellungen folgen nun Umbenennungen von MELCloud-Gebäuden beim Aktualisieren.",
+    "en": "Settings now follow MELCloud building renames on refresh.",
+    "es": "Los ajustes ahora siguen los cambios de nombre de los edificios de MELCloud al actualizar.",
+    "fr": "Les réglages suivent désormais les renommages de bâtiments MELCloud au rafraîchissement.",
+    "it": "Le impostazioni ora seguono le ridenominazioni degli edifici MELCloud all’aggiornamento.",
+    "ko": "이제 설정이 새로 고침 시 MELCloud 건물 이름 변경을 반영합니다.",
+    "nl": "De instellingen volgen nu hernoemingen van MELCloud-gebouwen bij het vernieuwen.",
+    "no": "Innstillingene følger nå navneendringer på MELCloud-bygninger ved oppdatering.",
+    "pl": "Ustawienia uwzględniają teraz zmiany nazw budynków MELCloud przy odświeżaniu.",
+    "ru": "Настройки теперь отражают переименования зданий MELCloud при обновлении.",
+    "sv": "Inställningarna följer nu namnbyten på MELCloud-byggnader vid uppdatering."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -190,5 +190,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.0"
+  "version": "24.7.1"
 }

--- a/api.mts
+++ b/api.mts
@@ -30,14 +30,21 @@ const api = {
    * Lists the settings rows: one named group per MELCloud building
    * (com.melcloud's inter-app grouping), unmatched devices trailing in
    * an unnamed group, or a single unnamed flat group when no grouping
-   * is available. Devices carry their configured outdoor source
-   * (`null` when they follow the Homey weather default).
+   * is available. The grouping is re-read from com.melcloud on every
+   * call (a memory-served lookup there since 45.2.0), so a building
+   * rename shows up on the next settings refresh. Devices carry their
+   * configured outdoor source (`null` when they follow the Homey
+   * weather default).
    * @param options - Homey API context.
    * @param options.homey - Homey instance carrying the app.
    * @returns The groups, sorted by name, devices sorted within.
    * @throws NotFoundError when no MELCloud AC device is paired yet.
    */
-  getAdjustableGroups({ homey }: { homey: Homey }): AdjustableGroup[] {
+  async getAdjustableGroups({
+    homey,
+  }: {
+    homey: Homey
+  }): Promise<AdjustableGroup[]> {
     const { app } = homey
     if (app.melcloudDevices.length === 0) {
       throw new NotFoundError()
@@ -45,7 +52,7 @@ const api = {
     return groupAdjustableDevices(
       app.melcloudDevices,
       app.homey.settings.get('outdoorSources') ?? {},
-      app.deviceGroups,
+      await app.refreshDeviceGroups(),
     )
   },
   /**

--- a/app.json
+++ b/app.json
@@ -191,5 +191,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.0"
+  "version": "24.7.1"
 }

--- a/app.mts
+++ b/app.mts
@@ -149,6 +149,17 @@ export default class MELCloudExtensionApp extends App {
     this.#persistLog(newLog)
   }
 
+  // Building grouping served by com.melcloud's inter-app API; anything
+  // off (older app version, not installed, bad payload) reads as "no
+  // grouping" and the settings fall back to the per-device list.
+  // Re-read on demand — a memory-served lookup in com.melcloud since
+  // 45.2.0 — so the settings page follows building renames without an
+  // app restart.
+  public async refreshDeviceGroups(): Promise<DeviceGroups | null> {
+    this.#deviceGroups = await this.#fetchDeviceGroups()
+    return this.#deviceGroups
+  }
+
   #createNotification(): void {
     const { homey } = this
     const {
@@ -190,9 +201,6 @@ export default class MELCloudExtensionApp extends App {
     this.#sources.clear()
   }
 
-  // Building grouping served by com.melcloud's inter-app API; anything
-  // off (older app version, not installed, bad payload) reads as "no
-  // grouping" and the settings fall back to the per-device list.
   async #fetchDeviceGroups(): Promise<DeviceGroups | null> {
     try {
       const payload: unknown = await this.#melcloudApp.get('/device_groups')
@@ -269,7 +277,7 @@ export default class MELCloudExtensionApp extends App {
         this.#temperatureSensors.push(device)
       }
     }
-    this.#deviceGroups = await this.#fetchDeviceGroups()
+    await this.refreshDeviceGroups()
     this.#migrateLegacySource()
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.0",
+  "version": "24.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.7.0",
+      "version": "24.7.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.0",
+  "version": "24.7.1",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -59,6 +59,9 @@ const createHomeyContext = ({
         },
       },
       melcloudDevices,
+      refreshDeviceGroups: vi
+        .fn<MELCloudExtensionApp['refreshDeviceGroups']>()
+        .mockResolvedValue(deviceGroups),
       temperatureSensors,
     }),
     i18n: { getLanguage: (): string => 'fr' },
@@ -98,16 +101,18 @@ describe('api', () => {
   })
 
   describe('getAdjustableGroups', () => {
-    it('should throw when no MELCloud AC device is paired', () => {
+    it('should throw when no MELCloud AC device is paired', async () => {
       const { homey } = createHomeyContext({
         melcloudDevices: [],
         temperatureSensors: [],
       })
 
-      expect(() => api.getAdjustableGroups({ homey })).toThrow('notFound')
+      await expect(api.getAdjustableGroups({ homey })).rejects.toThrow(
+        'notFound',
+      )
     })
 
-    it('should fall back to a single flat group without grouping', () => {
+    it('should fall back to a single flat group without grouping', async () => {
       const { homey } = createHomeyContext({
         melcloudDevices: [classicDevice.device, homeDevice.device],
         settings: {
@@ -116,7 +121,7 @@ describe('api', () => {
         temperatureSensors: [],
       })
 
-      expect(api.getAdjustableGroups({ homey })).toStrictEqual([
+      await expect(api.getAdjustableGroups({ homey })).resolves.toStrictEqual([
         {
           devices: [
             { id: 'home-1', name: 'Bedroom', outdoorSource: 'none' },
@@ -127,7 +132,7 @@ describe('api', () => {
       ])
     })
 
-    it('should group by building, merging same-name buildings across dialects', () => {
+    it('should group by building, merging same-name buildings across dialects', async () => {
       const { homey } = createHomeyContext({
         deviceGroups: [
           { deviceIds: ['1'], name: 'Domicile' },
@@ -137,7 +142,7 @@ describe('api', () => {
         temperatureSensors: [],
       })
 
-      expect(api.getAdjustableGroups({ homey })).toStrictEqual([
+      await expect(api.getAdjustableGroups({ homey })).resolves.toStrictEqual([
         {
           devices: [
             { id: 'home-1', name: 'Bedroom', outdoorSource: null },
@@ -148,7 +153,7 @@ describe('api', () => {
       ])
     })
 
-    it('should leave a device without a usable join id unmatched', () => {
+    it('should leave a device without a usable join id unmatched', async () => {
       const bareDevice = createMockDevice({
         driverId: 'homey:app:com.mecloud:melcloud',
         id: 'bare-1',
@@ -161,7 +166,7 @@ describe('api', () => {
         temperatureSensors: [],
       })
 
-      expect(api.getAdjustableGroups({ homey })).toStrictEqual([
+      await expect(api.getAdjustableGroups({ homey })).resolves.toStrictEqual([
         {
           devices: [{ id: 'bare-1', name: 'Bare', outdoorSource: null }],
           name: null,
@@ -169,7 +174,7 @@ describe('api', () => {
       ])
     })
 
-    it('should sort named groups alphabetically', () => {
+    it('should sort named groups alphabetically', async () => {
       const { homey } = createHomeyContext({
         deviceGroups: [
           { deviceIds: ['1'], name: 'Maison B' },
@@ -179,24 +184,27 @@ describe('api', () => {
         temperatureSensors: [],
       })
 
-      expect(
-        api.getAdjustableGroups({ homey }).map(({ name }) => name),
-      ).toStrictEqual(['Maison A', 'Maison B'])
+      const groups = await api.getAdjustableGroups({ homey })
+
+      expect(groups.map(({ name }) => name)).toStrictEqual([
+        'Maison A',
+        'Maison B',
+      ])
     })
 
-    it('should trail the unnamed group behind a later-inserted named one', () => {
+    it('should trail the unnamed group behind a later-inserted named one', async () => {
       const { homey } = createHomeyContext({
         deviceGroups: [{ deviceIds: ['1'], name: 'Domicile' }],
         melcloudDevices: [classicDevice.device, homeDevice.device],
         temperatureSensors: [],
       })
 
-      expect(
-        api.getAdjustableGroups({ homey }).map(({ name }) => name),
-      ).toStrictEqual(['Domicile', null])
+      const groups = await api.getAdjustableGroups({ homey })
+
+      expect(groups.map(({ name }) => name)).toStrictEqual(['Domicile', null])
     })
 
-    it('should trail unmatched devices in an unnamed group', () => {
+    it('should trail unmatched devices in an unnamed group', async () => {
       const { homey } = createHomeyContext({
         deviceGroups: [{ deviceIds: ['1'], name: 'Domicile' }],
         // Unmatched device first: the unnamed group must still trail
@@ -204,7 +212,7 @@ describe('api', () => {
         temperatureSensors: [],
       })
 
-      expect(api.getAdjustableGroups({ homey })).toStrictEqual([
+      await expect(api.getAdjustableGroups({ homey })).resolves.toStrictEqual([
         {
           devices: [
             { id: 'classic-1', name: 'Living room', outdoorSource: null },

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -139,6 +139,27 @@ describe(MELCloudExtensionApp, () => {
     expect(app.deviceGroups).toStrictEqual(groups)
   })
 
+  it('should re-read the grouping on demand, following a rename', async () => {
+    const { classicDevice } = createDevices()
+    const { app, mockHomey } = await createHarness([classicDevice])
+    mockHomey.apiAppGet.mockReturnValue([
+      { deviceIds: ['classic-1'], name: 'Domicile' },
+    ])
+
+    await advancePastInit()
+
+    mockHomey.apiAppGet.mockReturnValue([
+      { deviceIds: ['classic-1'], name: 'Nouvelle maison' },
+    ])
+
+    await expect(app.refreshDeviceGroups()).resolves.toStrictEqual([
+      { deviceIds: ['classic-1'], name: 'Nouvelle maison' },
+    ])
+    expect(app.deviceGroups).toStrictEqual([
+      { deviceIds: ['classic-1'], name: 'Nouvelle maison' },
+    ])
+  })
+
   it('should read an off-shape grouping payload as no grouping', async () => {
     const { classicDevice } = createDevices()
     const { app, mockHomey } = await createHarness([classicDevice])


### PR DESCRIPTION
## What

`getAdjustableGroups` now re-reads the com.melcloud building grouping on every call — through a new `App.refreshDeviceGroups()` — instead of serving a cache only filled at init and device add/delete.

## Why

Two freshness gaps closed at once:
- a `null` cache (com.melcloud briefly unreachable at boot) self-heals on the next settings open;
- the settings **Refresh** button now reflects MELCloud building renames without an app restart.

Since com.melcloud 45.2.0 the `/device_groups` endpoint is served from its in-memory registries (no cloud call, no sync interference), so the re-read costs one local IPC.

## Release

24.7.1 — changelog ×13 locales, compose + package bumped, `homey:validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)