### PR TITLE
Settings page cannot hang on the loading overlay any more

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -17,22 +17,23 @@
     "thermostatMode": "الوضع"
   },
   "settings": {
+    "allDevices": "جميع الأجهزة",
     "autoAdjust": "ضبط درجة حرارة مكيف الهواء تلقائيًا",
     "boolean": {
       "false": "لا",
       "true": "نعم"
     },
+    "configuration": "التكوين",
     "defaultSource": "طقس Homey",
     "disabledSource": "عدم الضبط",
     "enabled": "الإبقاء ضمن 8 °C من درجة الحرارة الخارجية",
+    "install": "تثبيت تطبيق MELCloud",
+    "loadFailed": "فشل التحميل",
     "log": "السجل",
     "notFound": "قم أولاً بإعداد أجهزتك في تطبيق MELCloud على Homey.",
     "refresh": "إعادة تحميل",
     "searchSource": "ابحث عن مصدر…",
     "title": "إعدادات امتداد MELCloud",
-    "update": "تحديث",
-    "allDevices": "جميع الأجهزة",
-    "install": "تثبيت تطبيق MELCloud",
-    "configuration": "التكوين"
+    "update": "تحديث"
   }
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -17,6 +17,7 @@
     "homeyWeather": "Homey-vejret"
   },
   "settings": {
+    "allDevices": "Alle enheder",
     "apply": "Anvend på alle luft-til-luft enheder",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
@@ -24,17 +25,17 @@
       "true": "Ja"
     },
     "capabilities": "Udendørstemperatur",
+    "configuration": "Konfiguration",
+    "defaultSource": "Homey-vejr",
+    "disabledSource": "Juster ikke",
     "enabled": "Hold inden for 8 °C af udendørstemperaturen",
+    "install": "Installér MELCloud-appen",
+    "loadFailed": "Indlæsning mislykkedes",
     "log": "Historik",
     "notFound": "Du skal først konfigurere dine enheder i MELCloud Homey-appen.",
     "refresh": "Genindlæs",
-    "title": "Indstillinger for MELCloud-udvidelse",
-    "defaultSource": "Homey-vejr",
-    "disabledSource": "Juster ikke",
     "searchSource": "Søg efter en kilde …",
-    "update": "Opdater",
-    "allDevices": "Alle enheder",
-    "install": "Installér MELCloud-appen",
-    "configuration": "Konfiguration"
+    "title": "Indstillinger for MELCloud-udvidelse",
+    "update": "Opdater"
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -17,22 +17,23 @@
     "thermostatMode": "der Modus"
   },
   "settings": {
+    "allDevices": "Alle Geräte",
     "autoAdjust": "Temperatur der Klimaanlage automatisch anpassen",
     "boolean": {
       "false": "Nein",
       "true": "Ja"
     },
+    "configuration": "Konfiguration",
     "defaultSource": "Homey-Wetter",
     "disabledSource": "Nicht anpassen",
     "enabled": "Innerhalb von 8 °C der Außentemperatur halten",
+    "install": "MELCloud-App installieren",
+    "loadFailed": "Laden fehlgeschlagen",
     "log": "Verlauf",
     "notFound": "Richten Sie zuerst Ihre Geräte in der MELCloud-Homey-App ein.",
     "refresh": "Neu laden",
     "searchSource": "Nach einer Quelle suchen …",
     "title": "Einstellungen der MELCloud-Erweiterung",
-    "update": "Aktualisieren",
-    "allDevices": "Alle Geräte",
-    "install": "MELCloud-App installieren",
-    "configuration": "Konfiguration"
+    "update": "Aktualisieren"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,6 +17,7 @@
     "homeyWeather": "the Homey weather"
   },
   "settings": {
+    "allDevices": "All devices",
     "apply": "Apply to all air-to-air devices",
     "autoAdjust": "Auto-adjust air conditioning temperature",
     "boolean": {
@@ -24,17 +25,17 @@
       "true": "Yes"
     },
     "capabilities": "Outdoor temperature",
+    "configuration": "Configuration",
+    "defaultSource": "Homey weather",
+    "disabledSource": "Do not adjust",
     "enabled": "Keep within 8 °C of the outdoor temperature",
+    "install": "Install the MELCloud app",
+    "loadFailed": "Loading failed",
     "log": "History",
     "notFound": "First, you need to set up your devices in the MELCloud Homey app.",
     "refresh": "Refresh",
-    "title": "MELCloud extension settings",
-    "defaultSource": "Homey weather",
-    "disabledSource": "Do not adjust",
     "searchSource": "Search for a source…",
-    "update": "Update",
-    "allDevices": "All devices",
-    "install": "Install the MELCloud app",
-    "configuration": "Configuration"
+    "title": "MELCloud extension settings",
+    "update": "Update"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -17,6 +17,7 @@
     "homeyWeather": "el tiempo de Homey"
   },
   "settings": {
+    "allDevices": "Todos los dispositivos",
     "apply": "Aplicar a todos los dispositivos aire-aire",
     "autoAdjust": "Autoajustar la temperatura del aire acondicionado",
     "boolean": {
@@ -24,17 +25,17 @@
       "true": "Sí"
     },
     "capabilities": "Temperatura exterior",
+    "configuration": "Configuración",
+    "defaultSource": "Tiempo de Homey",
+    "disabledSource": "No ajustar",
     "enabled": "Mantener dentro de los 8 °C de la temperatura exterior",
+    "install": "Instalar la aplicación MELCloud",
+    "loadFailed": "Error al cargar",
     "log": "Historial",
     "notFound": "Primero, debes configurar tus dispositivos en la aplicación Homey MELCloud.",
     "refresh": "Recargar",
-    "title": "Configuración de la extensión para MELCloud",
-    "defaultSource": "Tiempo de Homey",
-    "disabledSource": "No ajustar",
     "searchSource": "Buscar una fuente…",
-    "update": "Actualizar",
-    "allDevices": "Todos los dispositivos",
-    "install": "Instalar la aplicación MELCloud",
-    "configuration": "Configuración"
+    "title": "Configuración de la extensión para MELCloud",
+    "update": "Actualizar"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -17,6 +17,7 @@
     "homeyWeather": "la météo Homey"
   },
   "settings": {
+    "allDevices": "Tous les appareils",
     "apply": "Appliquer à tous les appareils air-air",
     "autoAdjust": "Auto-ajuster la température de la climatisation",
     "boolean": {
@@ -24,17 +25,17 @@
       "true": "Oui"
     },
     "capabilities": "Température extérieure",
+    "configuration": "Configuration",
+    "defaultSource": "Météo Homey",
+    "disabledSource": "Ne pas activer",
     "enabled": "Maintenir à moins de 8 °C de la température extérieure",
+    "install": "Installer l'app MELCloud",
+    "loadFailed": "Le chargement a échoué",
     "log": "Historique",
     "notFound": "Vous devez d'abord configurer vos appareils dans l'appli Homey MELCloud.",
     "refresh": "Rafraîchir",
-    "title": "Paramètres de l'extension pour MELCloud",
-    "defaultSource": "Météo Homey",
-    "disabledSource": "Ne pas activer",
     "searchSource": "Rechercher une source…",
-    "update": "Mettre à jour",
-    "allDevices": "Tous les appareils",
-    "install": "Installer l'app MELCloud",
-    "configuration": "Configuration"
+    "title": "Paramètres de l'extension pour MELCloud",
+    "update": "Mettre à jour"
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -17,22 +17,23 @@
     "thermostatMode": "la modalità"
   },
   "settings": {
+    "allDevices": "Tutti i dispositivi",
     "autoAdjust": "Regola automaticamente la temperatura del climatizzatore",
     "boolean": {
       "false": "No",
       "true": "Sì"
     },
+    "configuration": "Configurazione",
     "defaultSource": "Meteo di Homey",
     "disabledSource": "Non regolare",
     "enabled": "Mantieni entro 8 °C dalla temperatura esterna",
+    "install": "Installa l'app MELCloud",
+    "loadFailed": "Caricamento non riuscito",
     "log": "Cronologia",
     "notFound": "Prima configura i tuoi dispositivi nell'app MELCloud per Homey.",
     "refresh": "Ricarica",
     "searchSource": "Cerca una fonte…",
     "title": "Impostazioni dell'estensione MELCloud",
-    "update": "Aggiorna",
-    "allDevices": "Tutti i dispositivi",
-    "install": "Installa l'app MELCloud",
-    "configuration": "Configurazione"
+    "update": "Aggiorna"
   }
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -17,22 +17,23 @@
     "thermostatMode": "모드"
   },
   "settings": {
+    "allDevices": "모든 장치",
     "autoAdjust": "에어컨 온도 자동 조절",
     "boolean": {
       "false": "아니요",
       "true": "예"
     },
+    "configuration": "구성",
     "defaultSource": "Homey 날씨",
     "disabledSource": "조절하지 않음",
     "enabled": "외부 온도와 8 °C 이내로 유지",
+    "install": "MELCloud 앱 설치",
+    "loadFailed": "로드에 실패했습니다",
     "log": "기록",
     "notFound": "먼저 MELCloud Homey 앱에서 장치를 설정하세요.",
     "refresh": "새로고침",
     "searchSource": "소스 검색…",
     "title": "MELCloud 확장 설정",
-    "update": "업데이트",
-    "allDevices": "모든 장치",
-    "install": "MELCloud 앱 설치",
-    "configuration": "구성"
+    "update": "업데이트"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -17,6 +17,7 @@
     "homeyWeather": "het Homey-weer"
   },
   "settings": {
+    "allDevices": "Alle apparaten",
     "apply": "Toepassen op alle lucht-lucht apparaten",
     "autoAdjust": "Auto-afstellen airco-temperatuur",
     "boolean": {
@@ -24,17 +25,17 @@
       "true": "Ja"
     },
     "capabilities": "Buitentemperatuur",
+    "configuration": "Configuratie",
+    "defaultSource": "Homey-weer",
+    "disabledSource": "Niet aanpassen",
     "enabled": "Blijf binnen 8 °C van de buitentemperatuur",
+    "install": "Installeer de MELCloud-app",
+    "loadFailed": "Laden mislukt",
     "log": "Overzicht",
     "notFound": "Je moet eerst je apparaten instellen in de MELCloud Homey app.",
     "refresh": "Herladen",
-    "title": "Instellingen van de MELCloud-extensie",
-    "defaultSource": "Homey-weer",
-    "disabledSource": "Niet aanpassen",
     "searchSource": "Zoek een bron…",
-    "update": "Updaten",
-    "allDevices": "Alle apparaten",
-    "install": "Installeer de MELCloud-app",
-    "configuration": "Configuratie"
+    "title": "Instellingen van de MELCloud-extensie",
+    "update": "Updaten"
   }
 }

--- a/locales/no.json
+++ b/locales/no.json
@@ -17,6 +17,7 @@
     "homeyWeather": "Homey-været"
   },
   "settings": {
+    "allDevices": "Alle enheter",
     "apply": "Bruk på alle luft-til-luft enheter",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
@@ -24,17 +25,17 @@
       "true": "Ja"
     },
     "capabilities": "Utetemperatur",
+    "configuration": "Konfigurasjon",
+    "defaultSource": "Homey-vær",
+    "disabledSource": "Ikke juster",
     "enabled": "Hold innenfor 8 °C av utetemperaturen",
+    "install": "Installer MELCloud-appen",
+    "loadFailed": "Innlasting mislyktes",
     "log": "Historikk",
     "notFound": "Først må du sette opp enhetene dine i MELCloud Homey-appen.",
     "refresh": "Gjenta",
-    "title": "Innstillinger for MELCloud-utvidelse",
-    "defaultSource": "Homey-vær",
-    "disabledSource": "Ikke juster",
     "searchSource": "Søk etter en kilde …",
-    "update": "Oppdater",
-    "allDevices": "Alle enheter",
-    "install": "Installer MELCloud-appen",
-    "configuration": "Konfigurasjon"
+    "title": "Innstillinger for MELCloud-utvidelse",
+    "update": "Oppdater"
   }
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -17,22 +17,23 @@
     "thermostatMode": "tryb"
   },
   "settings": {
+    "allDevices": "Wszystkie urządzenia",
     "autoAdjust": "Automatycznie dostosowuj temperaturę klimatyzacji",
     "boolean": {
       "false": "Nie",
       "true": "Tak"
     },
+    "configuration": "Konfiguracja",
     "defaultSource": "Pogoda Homey",
     "disabledSource": "Nie dostosowuj",
     "enabled": "Utrzymuj w granicach 8 °C od temperatury zewnętrznej",
+    "install": "Zainstaluj aplikację MELCloud",
+    "loadFailed": "Ładowanie nie powiodło się",
     "log": "Historia",
     "notFound": "Najpierw skonfiguruj urządzenia w aplikacji MELCloud dla Homey.",
     "refresh": "Odśwież",
     "searchSource": "Szukaj źródła…",
     "title": "Ustawienia rozszerzenia MELCloud",
-    "update": "Aktualizuj",
-    "allDevices": "Wszystkie urządzenia",
-    "install": "Zainstaluj aplikację MELCloud",
-    "configuration": "Konfiguracja"
+    "update": "Aktualizuj"
   }
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -17,22 +17,23 @@
     "thermostatMode": "режим"
   },
   "settings": {
+    "allDevices": "Все устройства",
     "autoAdjust": "Автоматически регулировать температуру кондиционера",
     "boolean": {
       "false": "Нет",
       "true": "Да"
     },
+    "configuration": "Конфигурация",
     "defaultSource": "Погода Homey",
     "disabledSource": "Не регулировать",
     "enabled": "Держать в пределах 8 °C от наружной температуры",
+    "install": "Установить приложение MELCloud",
+    "loadFailed": "Не удалось загрузить",
     "log": "История",
     "notFound": "Сначала настройте устройства в приложении MELCloud для Homey.",
     "refresh": "Загрузить",
     "searchSource": "Поиск источника…",
     "title": "Настройки расширения MELCloud",
-    "update": "Обновить",
-    "allDevices": "Все устройства",
-    "install": "Установить приложение MELCloud",
-    "configuration": "Конфигурация"
+    "update": "Обновить"
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -17,6 +17,7 @@
     "homeyWeather": "Homey-vädret"
   },
   "settings": {
+    "allDevices": "Alla enheter",
     "apply": "Tillämpa på alla luft-till-luft enheter",
     "autoAdjust": "Autojustera luftkonditioneringstemperaturen",
     "boolean": {
@@ -24,17 +25,17 @@
       "true": "Ja"
     },
     "capabilities": "Utomhustemperatur",
+    "configuration": "Konfiguration",
+    "defaultSource": "Homey-väder",
+    "disabledSource": "Justera inte",
     "enabled": "Håll inom 8 °C från utomhustemperaturen",
+    "install": "Installera MELCloud-appen",
+    "loadFailed": "Inläsningen misslyckades",
     "log": "Historik",
     "notFound": "Du behöver först konfigurera dina enheter i MELCloud Homey-appen.",
     "refresh": "Ladda om",
-    "title": "Inställningar för MELCloud-tillägg",
-    "defaultSource": "Homey-väder",
-    "disabledSource": "Justera inte",
     "searchSource": "Sök efter en källa …",
-    "update": "Uppdatera",
-    "allDevices": "Alla enheter",
-    "install": "Installera MELCloud-appen",
-    "configuration": "Konfiguration"
+    "title": "Inställningar för MELCloud-tillägg",
+    "update": "Uppdatera"
   }
 }

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -19,7 +19,9 @@ await build({
 
 // Cache-bust the static references: the phone webviews cache settings
 // assets across app versions, so a content hash per file forces a refetch
-// exactly when a file changes.
+// exactly when a file changes. Every occurrence of a local reference —
+// attributes and the inline entry's dynamic import alike — gets the same
+// stamp (a modulepreload only helps when its URL matches the import's).
 const hashOf = async (path) => {
   const content = await readFile(path)
   return createHash('sha256').update(content).digest('hex').slice(0, 8)
@@ -27,15 +29,24 @@ const hashOf = async (path) => {
 
 const htmlPath = 'settings/index.html'
 const html = await readFile(htmlPath, 'utf8')
-const stamped = html
-  .replace(
-    /index\.mjs(?:\?v=[0-9a-f]+)?/u,
-    `index.mjs?v=${await hashOf('settings/index.mjs')}`,
+const files = new Set(
+  [
+    ...html.matchAll(
+      /(?:href="|src="|import\('\.\/)(?<file>[^"':?/][^"':?]*)(?:\?v=[0-9a-f]+)?["')]/gu,
+    ),
+  ].map((match) => match.groups.file),
+)
+let stamped = html
+for (const file of files) {
+  const hash = await hashOf(`settings/${file}`)
+  stamped = stamped.replaceAll(
+    new RegExp(
+      `${file.replaceAll('.', String.raw`\.`)}(?:\\?v=[0-9a-f]+)?`,
+      'gu',
+    ),
+    `${file}?v=${hash}`,
   )
-  .replace(
-    /styles\.css(?:\?v=[0-9a-f]+)?/u,
-    `styles.css?v=${await hashOf('settings/styles.css')}`,
-  )
+}
 if (stamped !== html) {
   await writeFile(htmlPath, stamped)
 }

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -39,11 +39,9 @@ const files = new Set(
 let stamped = html
 for (const file of files) {
   const hash = await hashOf(`settings/${file}`)
+  const escaped = file.replaceAll('.', String.raw`\.`)
   stamped = stamped.replaceAll(
-    new RegExp(
-      `${file.replaceAll('.', String.raw`\.`)}(?:\\?v=[0-9a-f]+)?`,
-      'gu',
-    ),
+    new RegExp(String.raw`${escaped}(?:\?v=[0-9a-f]+)?`, 'gu'),
     `${file}?v=${hash}`,
   )
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -14,7 +14,11 @@
                     .catch((error) => {
                         globalThis.reportError?.(error)
                         homey.ready()
-                        homey.alert(homey.__('settings.loadFailed'))
+                        homey
+                            .alert(homey.__('settings.loadFailed'))
+                            .catch((alertError) => {
+                                globalThis.reportError?.(alertError)
+                            })
                     })
             }
         </script>

--- a/settings/index.html
+++ b/settings/index.html
@@ -9,7 +9,7 @@
             // needs this global at parse time. The page logic lives in the
             // module bundle; a failed bundle load still ends the overlay.
             function onHomeyReady(homey) {
-                import('./index.mjs?v=d5f15b27')
+                import('./index.mjs?v=d726f7cf')
                     .then((module) => module.start(homey))
                     .catch((error) => {
                         globalThis.reportError?.(error)
@@ -23,7 +23,7 @@
             }
         </script>
         <link href="styles.css?v=364176a1" rel="stylesheet">
-        <link href="index.mjs?v=d5f15b27" rel="modulepreload">
+        <link href="index.mjs?v=d726f7cf" rel="modulepreload">
         <script data-origin="settings" defer src="/homey.js"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>

--- a/settings/index.html
+++ b/settings/index.html
@@ -4,9 +4,16 @@
         <meta charset="utf-8">
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Extension Settings</title>
+        <script>
+            // Registered at parse time: the Homey SDK may dispatch
+            // onHomeyReady before the module bundle below has loaded.
+            window.homeyReady = new Promise((resolve) => {
+                window.onHomeyReady = resolve
+            })
+        </script>
         <link href="styles.css?v=12811196" rel="stylesheet">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs?v=44b3ed39"></script>
+        <script type="module" src="index.mjs?v=f1f15a34"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>

--- a/settings/index.html
+++ b/settings/index.html
@@ -5,15 +5,21 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Extension Settings</title>
         <script>
-            // Registered at parse time: the Homey SDK may dispatch
-            // onHomeyReady before the module bundle below has loaded.
-            window.homeyReady = new Promise((resolve) => {
-                window.onHomeyReady = resolve
-            })
+            // Canonical entry point from the app-settings docs: the SDK
+            // needs this global at parse time. The page logic lives in the
+            // module bundle; a failed bundle load still ends the overlay.
+            function onHomeyReady(homey) {
+                import('./index.mjs?v=3b51b21d')
+                    .then((module) => module.start(homey))
+                    .catch(() => {
+                        homey.ready()
+                        homey.alert('Failed to load the settings page')
+                    })
+            }
         </script>
         <link href="styles.css?v=12811196" rel="stylesheet">
+        <link href="index.mjs" rel="modulepreload">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs?v=4caeef64"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>

--- a/settings/index.html
+++ b/settings/index.html
@@ -18,7 +18,7 @@
                     })
             }
         </script>
-        <link href="styles.css?v=12811196" rel="stylesheet">
+        <link href="styles.css?v=364176a1" rel="stylesheet">
         <link href="index.mjs?v=d5f15b27" rel="modulepreload">
         <script data-origin="settings" defer src="/homey.js"></script>
         <meta content="MELCloud extension settings" name="description">

--- a/settings/index.html
+++ b/settings/index.html
@@ -9,16 +9,17 @@
             // needs this global at parse time. The page logic lives in the
             // module bundle; a failed bundle load still ends the overlay.
             function onHomeyReady(homey) {
-                import('./index.mjs?v=3b51b21d')
+                import('./index.mjs?v=d5f15b27')
                     .then((module) => module.start(homey))
-                    .catch(() => {
+                    .catch((error) => {
+                        globalThis.reportError?.(error)
                         homey.ready()
-                        homey.alert('Failed to load the settings page')
+                        homey.alert(homey.__('settings.loadFailed'))
                     })
             }
         </script>
         <link href="styles.css?v=12811196" rel="stylesheet">
-        <link href="index.mjs" rel="modulepreload">
+        <link href="index.mjs?v=d5f15b27" rel="modulepreload">
         <script data-origin="settings" defer src="/homey.js"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>

--- a/settings/index.html
+++ b/settings/index.html
@@ -13,7 +13,7 @@
         </script>
         <link href="styles.css?v=12811196" rel="stylesheet">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs?v=d5a0e249"></script>
+        <script type="module" src="index.mjs?v=4caeef64"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>

--- a/settings/index.html
+++ b/settings/index.html
@@ -13,7 +13,7 @@
         </script>
         <link href="styles.css?v=12811196" rel="stylesheet">
         <script data-origin="settings" defer src="/homey.js"></script>
-        <script type="module" src="index.mjs?v=f1f15a34"></script>
+        <script type="module" src="index.mjs?v=d5a0e249"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -12,13 +12,6 @@ import {
   DISABLED_SOURCE,
 } from '../types.mts'
 
-declare global {
-  // Resolved by the inline bootstrap the settings HTML registers at parse
-  // time (see the <script> in the page head) with the instance the SDK
-  // hands to onHomeyReady — the declaration IS that parse boundary.
-  var homeyReady: Promise<Homey>
-}
-
 // Give slow transports a real chance while keeping the loading overlay
 // finite: past this point the page surfaces the failure instead.
 const INIT_TIMEOUT_MS = 10_000
@@ -158,16 +151,6 @@ const closeOpenCombobox = (): void => {
   openCombobox.close?.()
   openCombobox.close = null
 }
-
-document.addEventListener('pointerdown', (event) => {
-  if (
-    event.target instanceof Element &&
-    event.target.closest('.combobox') !== null
-  ) {
-    return
-  }
-  closeOpenCombobox()
-})
 
 // "Update" only means something once the form diverges from the last
 // saved state — the snapshot greys it out otherwise.
@@ -748,6 +731,16 @@ const refreshAll = async (homey: Homey): Promise<void> =>
   })
 
 const addEventListeners = (homey: Homey): void => {
+  // Any pointer press outside a combobox dismisses the open one.
+  document.addEventListener('pointerdown', (event) => {
+    if (
+      event.target instanceof Element &&
+      event.target.closest('.combobox') !== null
+    ) {
+      return
+    }
+    closeOpenCombobox()
+  })
   refreshElement.addEventListener('click', () => {
     fireAndForget(refreshAll(homey))
   })
@@ -770,15 +763,16 @@ const run = async (homey: Homey): Promise<void> => {
   await refreshAll(homey)
 }
 
-// `ready()` always fires — an unbounded await here would hold Homey's
-// loading overlay open forever on a single hung or failed call. The
-// failure alert waits until after `ready()`: an alert raised while the
-// overlay is still up never gets seen.
-const start = async (): Promise<void> => {
-  // The SDK calls onHomeyReady on its own schedule — possibly before this
-  // module has even been fetched — hence the await on the bootstrap's
-  // promise rather than a callback defined here.
-  const homey = await globalThis.homeyReady
+/**
+ * Page entry point, invoked by the HTML's canonical `onHomeyReady` once
+ * the SDK has dispatched (see the inline script in the page head).
+ * `ready()` always fires — an unbounded await here would hold Homey's
+ * loading overlay open forever on a single hung or failed call. The
+ * failure alert waits until after `ready()`: an alert raised while the
+ * overlay is still up never gets seen.
+ * @param homey - The Homey instance handed to `onHomeyReady`.
+ */
+export const start = async (homey: Homey): Promise<void> => {
   // Listeners before the data load: the Refresh button is the retry
   // affordance when the initial load fails or times out, so it must work
   // regardless of how `run` ends.
@@ -798,6 +792,3 @@ const start = async (): Promise<void> => {
     await homey.alert(getErrorMessage(initError))
   }
 }
-
-// eslint-disable-next-line unicorn/prefer-top-level-await -- a top-level await would need an es2022 bundle target and could deadlock: the module would suspend on `homeyReady` while the SDK may wait for module evaluation before dispatching it
-fireAndForget(start())

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -186,12 +186,25 @@ const setButtonsBusy = (areBusy: boolean): void => {
   updateDirty()
 }
 
+// Generation-tokened: a hung action force-released by the init timeout
+// must not clear (or re-set) the busy state a later, live action owns.
+const busyGeneration = { value: 0 }
+
+const releaseBusyButtons = (): void => {
+  busyGeneration.value += 1
+  setButtonsBusy(false)
+}
+
 const withBusyButtons = async (action: () => Promise<void>): Promise<void> => {
+  busyGeneration.value += 1
+  const generation = busyGeneration.value
   setButtonsBusy(true)
   try {
     await action()
   } finally {
-    setButtonsBusy(false)
+    if (generation === busyGeneration.value) {
+      setButtonsBusy(false)
+    }
   }
 }
 
@@ -763,6 +776,17 @@ const run = async (homey: Homey): Promise<void> => {
   await refreshAll(homey)
 }
 
+// A timed-out load may still be hung inside `withBusyButtons` — release
+// the controls (and orphan that run's busy claim) so the retry is
+// actually clickable.
+const reportInitFailure = async (
+  homey: Homey,
+  error: unknown,
+): Promise<void> => {
+  releaseBusyButtons()
+  await homey.alert(getErrorMessage(error))
+}
+
 /**
  * Page entry point, invoked by the HTML's canonical `onHomeyReady` once
  * the SDK has dispatched (see the inline script in the page head).
@@ -777,18 +801,17 @@ export const start = async (homey: Homey): Promise<void> => {
   // affordance when the initial load fails or times out, so it must work
   // regardless of how `run` ends.
   addEventListeners(homey)
-  let initError: unknown = null
+  let initError: unknown
+  let hasInitFailed = false
   try {
     await withInitTimeout(run(homey))
   } catch (error) {
     initError = error
+    hasInitFailed = true
   } finally {
     homey.ready()
   }
-  if (initError !== null) {
-    // A timed-out load may still be hung inside `withBusyButtons` —
-    // release the controls so the retry is actually clickable.
-    setButtonsBusy(false)
-    await homey.alert(getErrorMessage(initError))
+  if (hasInitFailed) {
+    await reportInitFailure(homey, initError)
   }
 }

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -778,13 +778,12 @@ const run = async (homey: Homey): Promise<void> => {
 
 // A timed-out load may still be hung inside `withBusyButtons` — release
 // the controls (and orphan that run's busy claim) so the retry is
-// actually clickable.
-const reportInitFailure = async (
-  homey: Homey,
-  error: unknown,
-): Promise<void> => {
+// actually clickable. Fire-and-forget on the alert keeps `start()`
+// non-throwing: a rejected alert must not trip the HTML loader's catch
+// (double `ready()`, second generic alert).
+const reportInitFailure = (homey: Homey, error: unknown): void => {
   releaseBusyButtons()
-  await homey.alert(getErrorMessage(error))
+  fireAndForget(homey.alert(getErrorMessage(error)))
 }
 
 /**
@@ -812,6 +811,6 @@ export const start = async (homey: Homey): Promise<void> => {
     homey.ready()
   }
   if (hasInitFailed) {
-    await reportInitFailure(homey, initError)
+    reportInitFailure(homey, initError)
   }
 }

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -12,6 +12,45 @@ import {
   DISABLED_SOURCE,
 } from '../types.mts'
 
+declare global {
+  // Resolved by the inline bootstrap the settings HTML registers at
+  // parse time (see the <script> in the page head).
+  var homeyReady: Promise<unknown>
+}
+
+// Give slow transports a real chance while keeping the loading overlay
+// finite: past this point the page surfaces the failure instead.
+const INIT_TIMEOUT_MS = 10_000
+
+// The Homey SDK calls `onHomeyReady` on its own schedule — possibly
+// before this module has been fetched and evaluated, so the handler must
+// exist at HTML parse time. The inline bootstrap registers it and exposes
+// the instance through `globalThis.homeyReady`; this is the module-side
+// await.
+const resolveHomey = async (): Promise<Homey> =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the SDK hands an untyped instance to onHomeyReady; this is that same parse boundary
+  (await globalThis.homeyReady) as Homey
+
+// Bounds the init chain: `Homey.ready()` must always end the loading
+// overlay, so a hung transport call cannot be allowed to hold it open
+// forever. The underlying work is not cancelled — a late success simply
+// repaints over the degraded state.
+const withInitTimeout = async <T,>(work: Promise<T>): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error('Timed out while loading data from the app'))
+        }, INIT_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 const LOG_RETENTION_DAYS = 6
 
 interface LogCategory {
@@ -730,7 +769,7 @@ const addEventListeners = (homey: Homey): void => {
   homey.on('log', displayLog)
 }
 
-const onHomeyReady = async (homey: Homey): Promise<void> => {
+const run = async (homey: Homey): Promise<void> => {
   try {
     await fetchLanguage(homey)
   } catch {
@@ -738,7 +777,26 @@ const onHomeyReady = async (homey: Homey): Promise<void> => {
   }
   await refreshAll(homey)
   addEventListeners(homey)
-  homey.ready()
 }
 
-Object.assign(globalThis, { onHomeyReady })
+// `ready()` always fires — an unbounded await here would hold Homey's
+// loading overlay open forever on a single hung or failed call. The
+// failure alert waits until after `ready()`: an alert raised while the
+// overlay is still up never gets seen.
+const start = async (): Promise<void> => {
+  const homey = await resolveHomey()
+  let initError: unknown = null
+  try {
+    await withInitTimeout(run(homey))
+  } catch (error) {
+    initError = error
+  } finally {
+    homey.ready()
+  }
+  if (initError !== null) {
+    await homey.alert(getErrorMessage(initError))
+  }
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- a top-level await would need an es2022 bundle target and could deadlock: the module would suspend on `homeyReady` while the SDK may wait for module evaluation before dispatching it
+fireAndForget(start())

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -776,7 +776,6 @@ const run = async (homey: Homey): Promise<void> => {
     // Non-critical: the log timestamps fall back to English formatting
   }
   await refreshAll(homey)
-  addEventListeners(homey)
 }
 
 // `ready()` always fires — an unbounded await here would hold Homey's
@@ -785,6 +784,10 @@ const run = async (homey: Homey): Promise<void> => {
 // overlay is still up never gets seen.
 const start = async (): Promise<void> => {
   const homey = await resolveHomey()
+  // Listeners before the data load: the Refresh button is the retry
+  // affordance when the initial load fails or times out, so it must work
+  // regardless of how `run` ends.
+  addEventListeners(homey)
   let initError: unknown = null
   try {
     await withInitTimeout(run(homey))
@@ -794,6 +797,9 @@ const start = async (): Promise<void> => {
     homey.ready()
   }
   if (initError !== null) {
+    // A timed-out load may still be hung inside `withBusyButtons` —
+    // release the controls so the retry is actually clickable.
+    setButtonsBusy(false)
     await homey.alert(getErrorMessage(initError))
   }
 }

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -13,23 +13,15 @@ import {
 } from '../types.mts'
 
 declare global {
-  // Resolved by the inline bootstrap the settings HTML registers at
-  // parse time (see the <script> in the page head).
-  var homeyReady: Promise<unknown>
+  // Resolved by the inline bootstrap the settings HTML registers at parse
+  // time (see the <script> in the page head) with the instance the SDK
+  // hands to onHomeyReady — the declaration IS that parse boundary.
+  var homeyReady: Promise<Homey>
 }
 
 // Give slow transports a real chance while keeping the loading overlay
 // finite: past this point the page surfaces the failure instead.
 const INIT_TIMEOUT_MS = 10_000
-
-// The Homey SDK calls `onHomeyReady` on its own schedule — possibly
-// before this module has been fetched and evaluated, so the handler must
-// exist at HTML parse time. The inline bootstrap registers it and exposes
-// the instance through `globalThis.homeyReady`; this is the module-side
-// await.
-const resolveHomey = async (): Promise<Homey> =>
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the SDK hands an untyped instance to onHomeyReady; this is that same parse boundary
-  (await globalThis.homeyReady) as Homey
 
 // Bounds the init chain: `Homey.ready()` must always end the loading
 // overlay, so a hung transport call cannot be allowed to hold it open
@@ -783,7 +775,10 @@ const run = async (homey: Homey): Promise<void> => {
 // failure alert waits until after `ready()`: an alert raised while the
 // overlay is still up never gets seen.
 const start = async (): Promise<void> => {
-  const homey = await resolveHomey()
+  // The SDK calls onHomeyReady on its own schedule — possibly before this
+  // module has even been fetched — hence the await on the bootstrap's
+  // promise rather than a callback defined here.
+  const homey = await globalThis.homeyReady
   // Listeners before the data load: the Refresh button is the retry
   // affordance when the initial load fails or times out, so it must work
   // regardless of how `run` ends.

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -2,15 +2,22 @@
   pointer-events: none;
 }
 
+/* Shared two-column grid: every row's time cell takes the width of the
+   longest one, so the messages align across rows whatever the relative
+   time's length ("il y a 1 heure" vs "il y a 13 heures"). */
+#logs {
+  column-gap: 1em;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  row-gap: 1em;
+}
+
 .log-row {
-  display: flex;
-  margin-block-end: 1em;
+  display: contents;
 }
 
 .log-time {
   color: #888;
-  flex-shrink: 0;
-  margin-inline-end: 1em;
   text-align: center;
   white-space: nowrap;
 }
@@ -108,5 +115,6 @@
 .log-day {
   color: #888;
   font-weight: 600;
+  grid-column: 1 / -1;
   padding-block: 0.5em;
 }


### PR DESCRIPTION
Extension counterpart of OlivierZal/com.melcloud#1406 — same audit against the official webview docs, same fix shape, kept literally on the docs' canonical form:

The HTML declares `function onHomeyReady(homey)` inline **exactly as the app-settings docs show**; its body `import()`s the bundle and hands the instance to the exported `start(homey)`. The inline `.catch` ends the overlay even when the bundle itself fails to load (a `modulepreload` hint keeps the fetch starting at parse time). Init is time-bounded (10 s), `ready()` fires in a `finally`, failures surface as a post-`ready` alert, listeners register before the load so Refresh is the retry affordance, and the error path releases the busy state a hung load would have left behind.

Cache busting (`?v=<content-hash>`) already existed in this repo — it was ported to com.melcloud in the sibling PR.

Code-only: the pending 24.7.1 release bits live in #1181. Suite: 100 tests, 100 % everywhere, build + validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)