### PR TITLE
Settings-page routes leave diagnostics breadcrumbs (align with com.melcloud #1412)

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -10,6 +10,15 @@ import {
   OUTDOOR_TEMPERATURE,
 } from './types.mts'
 
+// Diagnostics breadcrumb: the settings webview is otherwise invisible in
+// diagnostic reports (its routes are all local IPC / inter-app reads, no
+// MELCloud round-trip to log), which would make "settings fail to load"
+// reports undecidable — no line = the page's JS never ran; lines without
+// a completed sequence = where it stopped. Mirrors com.melcloud.
+const logSettingsRoute = (app: Homey['app'], route: string): void => {
+  app.log({ dataType: 'Settings page', route })
+}
+
 const api = {
   /**
    * Starts or restarts automatic cooling adjustment from the settings UI.
@@ -46,6 +55,7 @@ const api = {
     homey: Homey
   }): Promise<AdjustableGroup[]> {
     const { app } = homey
+    logSettingsRoute(app, '/devices/groups')
     if (app.melcloudDevices.length === 0) {
       throw new NotFoundError()
     }
@@ -61,8 +71,10 @@ const api = {
    * @param options.homey - Homey instance carrying the i18n manager.
    * @returns The BCP-47 language tag (e.g. `en`, `fr`).
    */
-  getLanguage: ({ homey: { i18n } }: { homey: Homey }): string =>
-    i18n.getLanguage(),
+  getLanguage: ({ homey: { app, i18n } }: { homey: Homey }): string => {
+    logSettingsRoute(app, '/language')
+    return i18n.getLanguage()
+  },
   /**
    * Lists the temperature capabilities selectable as outdoor source,
    * sorted by display name. MELCloud AC devices only expose their
@@ -75,6 +87,7 @@ const api = {
    */
   getTemperatureSensors({ homey }: { homey: Homey }): TemperatureSensor[] {
     const { melcloudDevices, temperatureSensors } = homey.app
+    logSettingsRoute(homey.app, '/devices/sensors/temperature')
     if (melcloudDevices.length === 0) {
       throw new NotFoundError()
     }

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -58,6 +58,7 @@ const createHomeyContext = ({
           get: (key: keyof HomeySettings): unknown => settings[key] ?? null,
         },
       },
+      log: vi.fn<(...args: readonly unknown[]) => void>(),
       melcloudDevices,
       refreshDeviceGroups: vi
         .fn<MELCloudExtensionApp['refreshDeviceGroups']>()


### PR DESCRIPTION
You asked to align the extension settings with com.melcloud's settings management. Verified the gap first: the extension's settings routes (`/language`, `/devices/groups`, `/devices/sensors/temperature`) leave **nothing** in the diagnostic log today (all local IPC / inter-app reads, no MELCloud round-trip), so a 'settings fail to load' report would be undecidable — exactly com.melcloud's pre-#1412 blind spot.

This mirrors #1412's `logSettingsRoute` breadcrumb on those three init routes:
- **no breadcrumb** → the webview never executed;
- **breadcrumbs then silence** → which call the init chain died on.

The extension's webview lifecycle was itself the subject of load-failure fixes (#1182), so this is cheap preemptive diagnosability for a demonstrably fragile surface — ~4 passive log lines, zero runtime cost. Code-only (no user-facing change); ships with the next extension release. Suite: 101 tests, 100 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)