### PR TITLE
Fix settings page failing to load on Android (static module) — 24.7.3

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -301,5 +301,20 @@
     "pl": "Lepsza diagnostyka, gdy strona ustawień się nie ładuje.",
     "ru": "Улучшена диагностика, когда страница настроек не загружается.",
     "sv": "Bättre diagnostik när inställningssidan inte laddas."
+  },
+  "24.7.3": {
+    "ar": "إصلاح فشل تحميل صفحة الإعدادات على أندرويد.",
+    "da": "Retter indstillingssiden, der ikke kunne indlæses på Android.",
+    "de": "Behebt das Nichtladen der Einstellungsseite auf Android.",
+    "en": "Fixes the settings page failing to load on Android.",
+    "es": "Corrige la página de ajustes que no cargaba en Android.",
+    "fr": "Corrige la page de réglages qui ne se chargeait pas sur Android.",
+    "it": "Corregge la pagina delle impostazioni che non si caricava su Android.",
+    "ko": "Android에서 설정 페이지가 로드되지 않던 문제를 수정했습니다.",
+    "nl": "Verhelpt de instellingenpagina die niet laadde op Android.",
+    "no": "Fikser innstillingssiden som ikke lastet på Android.",
+    "pl": "Naprawia stronę ustawień, która nie ładowała się na Androidzie.",
+    "ru": "Исправлена загрузка страницы настроек на Android.",
+    "sv": "Åtgärdar inställningssidan som inte laddades på Android."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -194,5 +194,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.2"
+  "version": "24.7.3"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,19 +75,30 @@ to judge success.
   melcloud.mts only imports the source as a type — no runtime cycle.
 - `settings/index.mts` — browser-side settings UI, bundled by esbuild
   into `settings/index.mjs` (ES module). Webview lifecycle (mirrors
-  com.melcloud): the HTML declares the docs' canonical global
-  `function onHomeyReady(homey)` inline — it must exist at parse time,
-  the SDK dispatches on its own schedule and a bundle only exists after
-  its fetch — whose body `import()`s the bundle and hands the instance
-  to its exported `start(homey)`; the inline `.catch` ends the overlay
-  even when the bundle itself fails to load. Init work is time-bounded
-  (10 s) and `homey.ready()` fires in a `finally`; `start` is
-  non-throwing by construction (failure alerts go through
+  com.melcloud): the SDK dispatches `onHomeyReady` on its own schedule,
+  before the bundle has loaded, so the HTML registers the handler in a
+  parse-time inline bootstrap that resolves `globalThis.homeyReady`. The
+  bundle loads as a **parser-discovered static
+  `<script type="module" src>`**, NOT a JS-initiated dynamic `import()`:
+  on Android the dynamic import fails to fetch against Homey's local
+  `.homeylocal.com` origin while parser-discovered resources (the
+  stylesheet) load — diagnosed from a com.melcloud v45.2.4 boot-error
+  report. A static module can only self-boot, so the entry module ends
+  with `fireAndForget(boot())` where `boot` awaits `globalThis.homeyReady`
+  and calls the (now non-exported) `start`. Two documented disables are
+  the honest cost: the SDK-handoff cast (parse boundary) and
+  `unicorn/prefer-top-level-await` — a top-level await would force an
+  es2022 target, and esbuild would then emit private fields natively
+  instead of lowering them, breaking older webview engines. The
+  `<script onerror>` posts a boot failure to `/boot-error` and ends the
+  overlay if the bundle itself fails to load; init work is otherwise
+  time-bounded (10 s) with `homey.ready()` in a `finally`, and `start`
+  is non-throwing by construction (failure alerts go through
   `fireAndForget`). `scripts/bundle.mjs` stamps every local asset
-  reference — attributes and the inline `import()` alike — with a
-  content hash (`?v=`): phone webviews cache assets across app
-  versions. Webview code sticks to es2020-era runtime APIs (esbuild
-  lowers syntax only). Settings pages and
+  reference (the stylesheet `href`, the module `src`) with a content
+  hash (`?v=`): phone webviews cache assets across app versions. Webview
+  code sticks to es2020-era runtime APIs (esbuild lowers syntax only).
+  Settings pages and
   widgets do NOT style the same way: settings follow the Homey Style
   Library (`homey-form-*`/`homey-button-*`; in a `homey-form-group` the
   control is a SIBLING after its label — see

--- a/app.json
+++ b/app.json
@@ -195,5 +195,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.2"
+  "version": "24.7.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.2",
+  "version": "24.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.7.2",
+      "version": "24.7.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.2",
+  "version": "24.7.3",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -19,9 +19,10 @@ await build({
 
 // Cache-bust the static references: the phone webviews cache settings
 // assets across app versions, so a content hash per file forces a refetch
-// exactly when a file changes. Every occurrence of a local reference —
-// attributes and the inline entry's dynamic import alike — gets the same
-// stamp (a modulepreload only helps when its URL matches the import's).
+// exactly when a file changes. Local files referenced from attributes —
+// the stylesheet `href` and the static module script `src` — get the same
+// stamp on every occurrence (the regex also covers a bare `import('./…')`,
+// none currently in the page).
 const hashOf = async (path) => {
   const content = await readFile(path)
   return createHash('sha256').update(content).digest('hex').slice(0, 8)

--- a/settings/index.html
+++ b/settings/index.html
@@ -5,27 +5,31 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Extension Settings</title>
         <script>
-            // Canonical entry point from the app-settings docs: the SDK
-            // needs this global at parse time. The page logic lives in the
-            // module bundle; a failed bundle load still ends the overlay.
-            function onHomeyReady(homey) {
-                import('./index.mjs?v=c3315fb2')
-                    .then((module) => module.start(homey))
-                    .catch((error) => {
+            // Registered at parse time: the SDK dispatches onHomeyReady on
+            // its own schedule, before the module bundle has loaded. The
+            // bundle loads as a parser-discovered static module (same fetch
+            // path as the stylesheet) rather than a JS-initiated dynamic
+            // import(), whose fetch fails on Android against Homey's local
+            // .homeylocal.com origin (diagnosed from a boot-error report on
+            // the sibling com.melcloud app, v45.2.4).
+            window.homeyReady = new Promise((resolve) => {
+                window.onHomeyReady = resolve
+            })
+            // onerror only fires if the module script itself fails to load;
+            // once it loads, its own init ends the overlay.
+            function reportSettingsBootFailure() {
+                window.homeyReady.then((homey) => {
+                    homey.api('POST', '/boot-error', { message: 'Failed to load the settings module script', name: 'BootError', stack: '' }, () => {})
+                    homey.ready()
+                    homey.alert(homey.__('settings.loadFailed')).catch((error) => {
                         globalThis.reportError?.(error)
-                        homey.api('POST', '/boot-error', { message: String((error && error.message) || error || ''), name: String((error && error.name) || ''), stack: String((error && error.stack) || '') }, () => {})
-                        homey.ready()
-                        homey
-                            .alert(homey.__('settings.loadFailed'))
-                            .catch((alertError) => {
-                                globalThis.reportError?.(alertError)
-                            })
                     })
+                })
             }
         </script>
         <link href="styles.css?v=364176a1" rel="stylesheet">
-        <link href="index.mjs?v=c3315fb2" rel="modulepreload">
         <script data-origin="settings" defer src="/homey.js"></script>
+        <script type="module" onerror="reportSettingsBootFailure()" src="index.mjs?v=b8a64866"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>
     <body>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -12,6 +12,12 @@ import {
   DISABLED_SOURCE,
 } from '../types.mts'
 
+declare global {
+  // Resolved by the page's inline bootstrap with the instance the SDK
+  // hands to onHomeyReady (see the <script> in the settings <head>).
+  var homeyReady: Promise<unknown>
+}
+
 // Give slow transports a real chance while keeping the loading overlay
 // finite: past this point the page surfaces the failure instead.
 const INIT_TIMEOUT_MS = 10_000
@@ -787,15 +793,15 @@ const reportInitFailure = (homey: Homey, error: unknown): void => {
 }
 
 /**
- * Page entry point, invoked by the HTML's canonical `onHomeyReady` once
- * the SDK has dispatched (see the inline script in the page head).
+ * Page entry point, run once the SDK hands over Homey through the
+ * parse-time bootstrap in the page head (see `boot` below).
  * `ready()` always fires — an unbounded await here would hold Homey's
  * loading overlay open forever on a single hung or failed call. The
  * failure alert waits until after `ready()`: an alert raised while the
  * overlay is still up never gets seen.
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
-export const start = async (homey: Homey): Promise<void> => {
+const start = async (homey: Homey): Promise<void> => {
   // Listeners before the data load: the Refresh button is the retry
   // affordance when the initial load fails or times out, so it must work
   // regardless of how `run` ends.
@@ -814,3 +820,18 @@ export const start = async (homey: Homey): Promise<void> => {
     reportInitFailure(homey, initError)
   }
 }
+
+// Entry module: the SDK hands over Homey via the parse-time bootstrap in
+// the page <head>. This file boots on that handoff rather than exporting
+// a start() for the HTML to call, because the bundle now loads as a
+// parser-discovered static <script type="module"> (a JS-initiated dynamic
+// import fails to fetch on Android against Homey's local origin) and a
+// static module can only self-boot.
+const boot = async (): Promise<void> => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the SDK passes an untyped instance to onHomeyReady; this is that parse boundary
+  const homey = (await globalThis.homeyReady) as Homey
+  await start(homey)
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- a top-level await would force an es2022 bundle target; esbuild then emits private fields natively instead of lowering them, breaking the older webview engines this static-load change exists to keep working
+fireAndForget(boot())


### PR DESCRIPTION
## Why this exists

The static-module change was authored on top of the 24.7.2 boot-capture branch, but PR #1189 was squash-merged while its head still pointed at the boot-capture commit — the follow-up static-fix commit never landed on `main`. This restores it as **24.7.3**, on top of the shipped boot-capture.

## Root cause (from the sibling com.melcloud app, fixed in 45.2.5)

The boot-error capture returned the exact error on Android:

```
TypeError: Failed to fetch dynamically imported module: …/index.mjs?v=…
```

A JS-initiated dynamic `import()` **fails to fetch on Android** against Homey's local `.homeylocal.com` origin, while parser-discovered resources (the stylesheet) load fine. The extension's settings page used the same inline `import()` pattern.

## Fix

The page loads its bundle as a static `<script type="module" src="index.mjs?v=…">` (same fetch path as the stylesheet). A parse-time inline bootstrap resolves `globalThis.homeyReady`; the entry module self-boots via `fireAndForget(boot())`. The `<script onerror>` keeps the 24.7.2 `/boot-error` POST + `ready()` safety net.

## The two disables are the honest cost

- **SDK-handoff cast** — the SDK passes an untyped instance to `onHomeyReady`; a sanctioned parse-boundary cast.
- **`unicorn/prefer-top-level-await`** — a top-level await would force an **es2022** target, and esbuild would then emit private fields natively instead of lowering them, breaking older webview engines. Keeping `boot()` + `fireAndForget` stays es2020. Justified inline and in CLAUDE.md.

Suite: 102 tests, backend coverage 100 %, `homey:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
