### PR TITLE
Classic defer IIFE webview delivery — fixes #1404 loading (24.7.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 /coverage/
 /env.json
 node_modules/
-/settings/index.mjs
+/settings/index.js
 /.claude/

--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -301,5 +301,20 @@
     "pl": "Lepsza diagnostyka, gdy strona ustawień się nie ładuje.",
     "ru": "Улучшена диагностика, когда страница настроек не загружается.",
     "sv": "Bättre diagnostik när inställningssidan inte laddas."
+  },
+  "24.7.3": {
+    "ar": "إصلاح فشل تحميل صفحة الإعدادات.",
+    "da": "Retter indstillingssiden, der ikke kunne indlæses.",
+    "de": "Behebt das Nichtladen der Einstellungsseite.",
+    "en": "Fixes the settings page failing to load.",
+    "es": "Corrige la página de ajustes que no cargaba.",
+    "fr": "Corrige la page de réglages qui ne se chargeait pas.",
+    "it": "Corregge la pagina delle impostazioni che non si caricava.",
+    "ko": "설정 페이지가 로드되지 않던 문제를 수정했습니다.",
+    "nl": "Verhelpt de instellingenpagina die niet laadde.",
+    "no": "Fikser innstillingssiden som ikke lastet.",
+    "pl": "Naprawia stronę ustawień, która się nie ładowała.",
+    "ru": "Исправлена загрузка страницы настроек.",
+    "sv": "Åtgärdar inställningssidan som inte laddades."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -15,10 +15,6 @@
     "getTemperatureSensors": {
       "method": "GET",
       "path": "/devices/sensors/temperature"
-    },
-    "logWebviewBoot": {
-      "method": "POST",
-      "path": "/boot-error"
     }
   },
   "author": {
@@ -194,5 +190,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.2"
+  "version": "24.7.3"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,11 @@ to judge success.
   cold. The HTML declares the docs' canonical global
   `function onHomeyReady(homey)` inline (it must exist at parse time),
   which polls `globalThis.MELCloudWebview` and calls its `start(homey)`.
-  `defer` (not com.melcloud's `async`) is deliberate: this entry does
-  DOM lookups at module top level, and `defer` runs the bundle only
-  after `<body>` parses, so they are safe; the poll's 10 s timeout still
-  ends the overlay if the script failed to load. Init work is separately
+  `defer` (as in com.melcloud) is the right fit for an app bundle that
+  reads the DOM — ordered, after `<body>` parses, before
+  DOMContentLoaded — and here it is doubly required: this entry does DOM
+  lookups at module top level, which `defer` makes safe. The poll's 10 s
+  timeout still ends the overlay if the script failed to load. Init work is separately
   time-bounded (10 s) with `homey.ready()` in a `finally`; `start` is
   non-throwing by construction (failure alerts go through
   `fireAndForget`). `scripts/bundle.mjs` stamps every local asset

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,20 +74,29 @@ to judge success.
   concurrent attaches await one start) and stops with the last `detach`.
   melcloud.mts only imports the source as a type — no runtime cycle.
 - `settings/index.mts` — browser-side settings UI, bundled by esbuild
-  into `settings/index.mjs` (ES module). Webview lifecycle (mirrors
-  com.melcloud): the HTML declares the docs' canonical global
-  `function onHomeyReady(homey)` inline — it must exist at parse time,
-  the SDK dispatches on its own schedule and a bundle only exists after
-  its fetch — whose body `import()`s the bundle and hands the instance
-  to its exported `start(homey)`; the inline `.catch` ends the overlay
-  even when the bundle itself fails to load. Init work is time-bounded
-  (10 s) and `homey.ready()` fires in a `finally`; `start` is
+  into `settings/index.js` as a CLASSIC IIFE (`format: 'iife'`,
+  `globalName: MELCloudWebview`), loaded via `<script defer src>` — NOT
+  an ES module (mirrors com.melcloud). Only the JS module loader fails:
+  `import()` / `<script type=module>` stall on a COLD webview open
+  against Homey's local origin (the #1404 spinner), while classic
+  resource fetches — the stylesheet, a classic `<script src>` — load
+  cold. The HTML declares the docs' canonical global
+  `function onHomeyReady(homey)` inline (it must exist at parse time),
+  which polls `globalThis.MELCloudWebview` and calls its `start(homey)`.
+  `defer` (not com.melcloud's `async`) is deliberate: this entry does
+  DOM lookups at module top level, and `defer` runs the bundle only
+  after `<body>` parses, so they are safe; the poll's 10 s timeout still
+  ends the overlay if the script failed to load. Init work is separately
+  time-bounded (10 s) with `homey.ready()` in a `finally`; `start` is
   non-throwing by construction (failure alerts go through
   `fireAndForget`). `scripts/bundle.mjs` stamps every local asset
-  reference — attributes and the inline `import()` alike — with a
-  content hash (`?v=`): phone webviews cache assets across app
-  versions. Webview code sticks to es2020-era runtime APIs (esbuild
-  lowers syntax only). Settings pages and
+  reference — only inside an attribute/import context, never a comment —
+  with a content hash (`?v=`): phone webviews cache assets across app
+  versions. NEVER load the bundle as an ES module: `import()` failed to
+  fetch on Android and a static `<script type=module>` spun every webview
+  forever on a cold open (both shipped and reverted in com.melcloud —
+  see its CLAUDE.md). Webview code sticks to es2020-era runtime APIs
+  (esbuild lowers syntax only). Settings pages and
   widgets do NOT style the same way: settings follow the Homey Style
   Library (`homey-form-*`/`homey-button-*`; in a `homey-form-group` the
   control is a SIBLING after its label — see

--- a/api.mts
+++ b/api.mts
@@ -110,15 +110,6 @@ const api = {
         sensor1.capabilityName.localeCompare(sensor2.capabilityName),
       )
   },
-  logWebviewBoot: ({
-    body,
-    homey: { app },
-  }: {
-    body: unknown
-    homey: Homey
-  }): void => {
-    app.error('Settings webview boot failed:', JSON.stringify(body))
-  },
 }
 
 export default api

--- a/app.json
+++ b/app.json
@@ -16,10 +16,6 @@
     "getTemperatureSensors": {
       "method": "GET",
       "path": "/devices/sensors/temperature"
-    },
-    "logWebviewBoot": {
-      "method": "POST",
-      "path": "/boot-error"
     }
   },
   "author": {
@@ -195,5 +191,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.2"
+  "version": "24.7.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.2",
+  "version": "24.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.7.2",
+      "version": "24.7.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.2",
+  "version": "24.7.3",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,27 +1,34 @@
-// Bundles the settings page into a single self-contained ES module served
-// statically by Homey, inlining npm dependencies (temporal-polyfill) so the
-// webview works offline with versions pinned by the lockfile.
+// Bundles the settings page into a single self-contained CLASSIC script
+// served statically by Homey, inlining npm dependencies (temporal-polyfill)
+// so the webview works offline with versions pinned by the lockfile. The
+// output is an IIFE (format: 'iife') exposing `start` on a global, loaded
+// via a plain `<script src>` — NOT an ES module. Module fetches (`import()`
+// / `<script type=module>`) stall on a cold webview open against Homey's
+// local origin (#1404); classic resource fetches, like the stylesheet,
+// load cold.
 import { createHash } from 'node:crypto'
 import { readFile, writeFile } from 'node:fs/promises'
 
 import { build } from 'esbuild'
 
+// The IIFE global the page's inline `onHomeyReady` reads `start` from.
+const GLOBAL_NAME = 'MELCloudWebview'
+
 await build({
   bundle: true,
   entryPoints: ['settings/index.mts'],
-  format: 'esm',
+  format: 'iife',
+  globalName: GLOBAL_NAME,
   legalComments: 'none',
   logLevel: 'info',
   minify: true,
-  outfile: 'settings/index.mjs',
+  outfile: 'settings/index.js',
   target: ['es2020'],
 })
 
 // Cache-bust the static references: the phone webviews cache settings
 // assets across app versions, so a content hash per file forces a refetch
-// exactly when a file changes. Every occurrence of a local reference —
-// attributes and the inline entry's dynamic import alike — gets the same
-// stamp (a modulepreload only helps when its URL matches the import's).
+// exactly when a file changes.
 const hashOf = async (path) => {
   const content = await readFile(path)
   return createHash('sha256').update(content).digest('hex').slice(0, 8)
@@ -29,22 +36,24 @@ const hashOf = async (path) => {
 
 const htmlPath = 'settings/index.html'
 const html = await readFile(htmlPath, 'utf8')
-const files = new Set(
-  [
-    ...html.matchAll(
-      /(?:href="|src="|import\('\.\/)(?<file>[^"':?/][^"':?]*)(?:\?v=[0-9a-f]+)?["')]/gu,
-    ),
-  ].map((match) => match.groups.file),
-)
-let stamped = html
-for (const file of files) {
-  const hash = await hashOf(`settings/${file}`)
-  const escaped = file.replaceAll('.', String.raw`\.`)
-  stamped = stamped.replaceAll(
-    new RegExp(String.raw`${escaped}(?:\?v=[0-9a-f]+)?`, 'gu'),
-    `${file}?v=${hash}`,
-  )
+// A local asset reference: an attribute value (href/src) or a dynamic
+// import specifier, with an optional existing stamp.
+const reference =
+  /(href="|src="|import\('\.\/)([^"':?/][^"':?]*)(?:\?v=[0-9a-f]+)?(["')])/gu
+// Hash each referenced asset up front — the replace below is sync.
+const hashes = new Map()
+for (const [, , file] of html.matchAll(reference)) {
+  if (!hashes.has(file)) {
+    hashes.set(file, await hashOf(`settings/${file}`))
+  }
 }
+// Stamp only within a reference context, so the same filename written
+// elsewhere (e.g. a comment) is never rewritten.
+const stamped = html.replaceAll(
+  reference,
+  (_match, prefix, file, suffix) =>
+    `${prefix}${file}?v=${hashes.get(file)}${suffix}`,
+)
 if (stamped !== html) {
   await writeFile(htmlPath, stamped)
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -5,26 +5,32 @@
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <title>MELCloud Extension Settings</title>
         <script>
-            // Canonical entry point from the app-settings docs: the SDK
-            // needs this global at parse time. The page logic lives in the
-            // module bundle; a failed bundle load still ends the overlay.
+            // The page bundle loads as a classic defer script, not an ES
+            // module: module fetches (import()/type=module) stall on a
+            // cold webview open against Homey's local origin (the #1404
+            // spinner), while classic resource fetches — like the
+            // stylesheet — load cold. defer runs it after <body> parses
+            // (so the entry's top-level DOM lookups are safe) and before
+            // onHomeyReady; the poll then hands the instance to the
+            // bundle's start, or the timeout ends the overlay if it
+            // failed to load.
             function onHomeyReady(homey) {
-                import('./index.mjs?v=c3315fb2')
-                    .then((module) => module.start(homey))
-                    .catch((error) => {
-                        globalThis.reportError?.(error)
-                        homey.api('POST', '/boot-error', { message: String((error && error.message) || error || ''), name: String((error && error.name) || ''), stack: String((error && error.stack) || '') }, () => {})
+                const deadline = Date.now() + 10000
+                const waitForBundle = () => {
+                    if (globalThis.MELCloudWebview) {
+                        globalThis.MELCloudWebview.start(homey)
+                    } else if (Date.now() > deadline) {
                         homey.ready()
-                        homey
-                            .alert(homey.__('settings.loadFailed'))
-                            .catch((alertError) => {
-                                globalThis.reportError?.(alertError)
-                            })
-                    })
+                        homey.alert(homey.__('settings.loadFailed')).catch(() => {})
+                    } else {
+                        setTimeout(waitForBundle, 50)
+                    }
+                }
+                waitForBundle()
             }
         </script>
         <link href="styles.css?v=364176a1" rel="stylesheet">
-        <link href="index.mjs?v=c3315fb2" rel="modulepreload">
+        <script defer src="index.js?v=f0e64b85"></script>
         <script data-origin="settings" defer src="/homey.js"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -122,6 +122,8 @@ const getSelectElement = (id: string): HTMLSelectElement =>
 const getDivElement = (id: string): HTMLDivElement =>
   getElement(id, HTMLDivElement, 'div')
 
+// Safe at module load: the bundle is a `defer` classic script, so it runs
+// only after <body> is parsed (see settings/index.html).
 const applyElement = getButtonElement('apply')
 const emptyElement = getDivElement('empty_state')
 const installElement = getButtonElement('install')

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -72,19 +72,6 @@ const createHomeyContext = ({
 }
 
 describe('api', () => {
-  describe('logWebviewBoot', () => {
-    it('should log the boot failure body via app.error', () => {
-      const { homey } = createHomeyContext({
-        melcloudDevices: [],
-        temperatureSensors: [],
-      })
-
-      api.logWebviewBoot({ body: { message: 'boom' }, homey })
-
-      expect(homey.app.error).toHaveBeenCalledTimes(1)
-    })
-  })
-
   describe('getLanguage', () => {
     it('should return the Homey language', () => {
       const { homey } = createHomeyContext({


### PR DESCRIPTION
## Classic IIFE webview delivery — the #1404 fix, mirrored from com.melcloud

The webview loading failures were the **JS module loader** specifically: `import()` failed to fetch on Android, while classic resource fetches (the stylesheet) load cold. The settings page now loads its bundle as a **classic `<script defer src="index.js">`** (esbuild `format: 'iife'`, `globalName: MELCloudWebview`); the inline `onHomeyReady` polls `globalThis.MELCloudWebview` and calls `start`, with a 10 s timeout fallback that ends the overlay if the script failed to load.

`defer` (not com.melcloud's `async`) is deliberate: this entry does DOM lookups at module top level, and `defer` runs the bundle only after `<body>` parses, so they're safe. Documented in CLAUDE.md.

## Cleanup

Removes the `/boot-error` diagnostic (`logWebviewBoot` route + compose + test) that the **unreleased** 24.7.2 boot-capture added — it existed only to capture module-load failures, now superfluous. Also fixes the `?v=` stamper to rewrite only inside a reference context (was replacing bare filenames anywhere, including comments).

Release 24.7.3. Suite green (lint/typecheck/tests/coverage/validate). Doctrine updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
