### PR TITLE
Full com.melcloud parity: compat + beacon + .homeybuild packaging + corrected causality (24.7.3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,22 @@ jobs:
       - uses: ./.github/actions/setup-node-and-install
         with:
           cache: none
-          install: 'false'
+          npm-token: ${{ secrets.GITHUB_TOKEN }}
+      # The settings bundles are gitignored esbuild outputs: without this
+      # step the packed app ships a settings page whose script src 404s
+      # on every store install ("Loading failed" — the com.melcloud #1404
+      # root cause; dev-installs mask it because the working tree holds
+      # local builds).
+      - name: Build webview bundles
+        run: npm run build:assets
+      - name: Assert the bundles are in the package
+        run: |
+          for file in settings/index.js settings/index.mjs; do
+            if [ ! -s "$file" ]; then
+              echo "::error::Missing webview bundle: $file"
+              exit 1
+            fi
+          done
       - id: publish
         name: Publish
         uses: athombv/github-action-homey-app-publish@0642b483f1eb66fbceb0c91b73df35d45fd2f3db

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,26 +17,28 @@ jobs:
         with:
           cache: none
           npm-token: ${{ secrets.GITHUB_TOKEN }}
-      # The settings bundles are gitignored esbuild outputs: without this
-      # step the packed app ships a settings page whose script src 404s
-      # on every store install ("Loading failed" — the com.melcloud #1404
-      # root cause; dev-installs mask it because the working tree holds
-      # local builds).
-      - name: Build webview bundles
-        run: npm run build:assets
-      - name: Assert the bundles are in the package
-        run: |
-          for file in settings/index.js settings/index.mjs; do
-            if [ ! -s "$file" ]; then
-              echo "::error::Missing webview bundle: $file"
-              exit 1
-            fi
-          done
       - id: publish
         name: Publish
         uses: athombv/github-action-homey-app-publish@0642b483f1eb66fbceb0c91b73df35d45fd2f3db
         with:
           personal_access_token: ${{ secrets.HOMEY_PAT }}
+      # The CLI's own `npm run build` (post-copy) must have emitted the
+      # settings bundles into .homeybuild and stamped the packaged page —
+      # a silent regression here is the com.melcloud #1404 class.
+      # Post-hoc by necessity (packing happens inside the action), so a
+      # failure here fails the workflow loudly right after the upload.
+      - name: Assert the packaged bundles
+        run: |
+          for file in settings/index.js settings/index.mjs; do
+            if [ ! -s ".homeybuild/$file" ]; then
+              echo "::error::Missing packaged bundle: .homeybuild/$file"
+              exit 1
+            fi
+          done
+          if ! grep -q 'index\.js?v=' .homeybuild/settings/index.html; then
+            echo "::error::Packaged settings HTML is unstamped"
+            exit 1
+          fi
       - name: URL
         env:
           URL: ${{ steps.publish.outputs.url }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /env.json
 node_modules/
 /settings/index.js
+/settings/index.mjs
 /.claude/

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -15,6 +15,10 @@
     "getTemperatureSensors": {
       "method": "GET",
       "path": "/devices/sensors/temperature"
+    },
+    "logWebviewBoot": {
+      "method": "POST",
+      "path": "/boot-error"
     }
   },
   "author": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,17 @@ to judge success.
   versions. NEVER load the bundle as an ES module: `import()` failed to
   fetch on Android and a static `<script type=module>` spun every webview
   forever on a cold open (both shipped and reverted in com.melcloud —
-  see its CLAUDE.md). Webview code sticks to es2020-era runtime APIs
-  (esbuild lowers syntax only). Settings pages and
+  see its CLAUDE.md). Phone webviews also cache the HTML ITSELF across
+  app versions (proven on com.melcloud), so shipped bundle filenames are
+  a COMPAT CONTRACT: `scripts/bundle.mjs` builds the entry twice —
+  `index.js` (IIFE) for the current HTML, `index.mjs` (ESM) for every
+  cached ESM-era HTML, which is why the entry keeps `export const
+start`. Never rename or drop a shipped bundle filename; add alongside.
+  When the bundle still fails to boot, the `onHomeyReady` poll's timeout
+  beacon POSTs the `userAgent` plus a `fetch` probe of the bundle to
+  `/boot-error` (`app.error`) before degrading, distinguishing a fetch
+  failure from a parse-or-runtime crash (pre-es2020 engines). Webview
+  code sticks to es2020-era runtime APIs (esbuild lowers syntax only). Settings pages and
   widgets do NOT style the same way: settings follow the Homey Style
   Library (`homey-form-*`/`homey-button-*`; in a `homey-form-group` the
   control is a SIBLING after its label — see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,13 +20,15 @@ Run the FULL suite before any push — CI runs all of it:
   and excluded.
 - `npm run build` — esbuild bundle (`scripts/bundle.mjs`) + `tsc` emit.
   `settings/index.{js,mjs}` are gitignored build outputs, never checked
-  in. The Homey CLI does NOT regenerate them — its pre-process runs only
-  its own TypeScript compile and copies everything else as-is (proven on
-  com.melcloud). Anything that packs the app ships whatever bundles sit
-  in the working tree: local installs work because the pre-push suite has
-  built them, and publish.yml MUST run `build:assets` before the publish
-  action — a store package without it 404s the settings script (the
-  com.melcloud #1404 root cause).
+  in. The Homey CLI runs `npm run build` when it detects TypeScript —
+  but only AFTER its pre-process copy into `.homeybuild`: the tsc emit
+  lands in `.homeybuild` and ships, while esbuild's outputs land in the
+  SOURCE tree too late to be copied (proven on com.melcloud — the #1404
+  root cause: store installs 404 the bundles). Local installs work
+  because the pre-push suite builds the bundles before the copy.
+  publish.yml therefore runs `build:assets` before the publish action
+  (the same pre-copy pattern as the local flow) and asserts both bundle
+  formats exist.
 - Cache-busting `?v=` — the build also stamps every local asset reference
   in the tracked `settings/index.html` with a content hash (`?v=<hash>`),
   so phone webviews (which cache assets across app versions) refetch an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,14 @@ Run the FULL suite before any push — CI runs all of it:
   100% (branches included), keep it there. `settings/` is browser glue
   and excluded.
 - `npm run build` — esbuild bundle (`scripts/bundle.mjs`) + `tsc` emit.
-  `settings/index.mjs` is a gitignored build output, never checked in;
-  the Homey CLI regenerates it on validate/install/run.
+  `settings/index.{js,mjs}` are gitignored build outputs, never checked
+  in. The Homey CLI does NOT regenerate them — its pre-process runs only
+  its own TypeScript compile and copies everything else as-is (proven on
+  com.melcloud). Anything that packs the app ships whatever bundles sit
+  in the working tree: local installs work because the pre-push suite has
+  built them, and publish.yml MUST run `build:assets` before the publish
+  action — a store package without it 404s the settings script (the
+  com.melcloud #1404 root cause).
 - Cache-busting `?v=` — the build also stamps every local asset reference
   in the tracked `settings/index.html` with a content hash (`?v=<hash>`),
   so phone webviews (which cache assets across app versions) refetch an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,31 +18,26 @@ Run the FULL suite before any push — CI runs all of it:
 - `npm test` / `npm run test:coverage` — vitest; backend coverage is at
   100% (branches included), keep it there. `settings/` is browser glue
   and excluded.
-- `npm run build` — esbuild bundle (`scripts/bundle.mjs`) + `tsc` emit.
-  `settings/index.{js,mjs}` are gitignored build outputs, never checked
-  in. The Homey CLI runs `npm run build` when it detects TypeScript —
-  but only AFTER its pre-process copy into `.homeybuild`: the tsc emit
-  lands in `.homeybuild` and ships, while esbuild's outputs land in the
-  SOURCE tree too late to be copied (proven on com.melcloud — the #1404
-  root cause: store installs 404 the bundles). Local installs work
-  because the pre-push suite builds the bundles before the copy.
-  publish.yml therefore runs `build:assets` before the publish action
-  (the same pre-copy pattern as the local flow) and asserts both bundle
-  formats exist.
-- Cache-busting `?v=` — the build also stamps every local asset reference
-  in the tracked `settings/index.html` with a content hash (`?v=<hash>`),
-  so phone webviews (which cache assets across app versions) refetch an
-  asset exactly when its bytes change. **Never hand-edit a `?v=` or bump
-  it "for a release": it is a content hash, not a version** — the build
-  sets it, and it moves automatically iff the asset content changes
-  (identical bytes → identical hash → no diff; a release that touches no
-  settings asset leaves every `?v=` untouched, which is correct). Because
-  the HTML is committed, any change to a bundled settings source
-  (`settings/index.mts`, `settings/styles.css`) must be followed by
-  `npm run build` and a commit of the re-stamped HTML. The mandatory
-  pre-push suite runs the build, so following it keeps the stamp in sync;
-  skipping it ships a stale `?v=` and phones keep serving the old cached
-  bundle — the exact staleness `?v=` exists to prevent.
+- `npm run build` — esbuild bundle (`scripts/bundle.mjs`) + `tsc`
+  emit, BOTH into `.homeybuild`. The Homey CLI runs `npm run build`
+  when it detects TypeScript — but only AFTER its pre-process copy into
+  `.homeybuild`, so the source tree stays sources-only and everything
+  the package needs must be emitted there: tsc does it via `outDir`,
+  and `bundle.mjs` emits the settings bundles there too (its former
+  source-tree outfiles landed too late to be copied — the com.melcloud
+  #1404 root cause: store installs 404'd the bundles). The CLI's own
+  build invocation is therefore sufficient for install, run, validate
+  and publish alike; a standalone suite run (no `.homeybuild` page
+  copy) still proves the bundles compile.
+- Cache-busting `?v=` — a PACKAGE-TIME transform: `bundle.mjs` stamps
+  every local asset reference of the `.homeybuild` page copy with a
+  content hash (`?v=<hash>`), so phone webviews (which cache assets
+  across app versions) refetch an asset exactly when its bytes change.
+  The committed source HTML carries NO stamps — never hand-add a `?v=`
+  there, and nothing needs re-committing when a settings source changes
+  (the old re-stamp-and-commit dance is gone). Stamps exist only in the
+  packaged app, and only within attribute/import reference contexts,
+  never comments.
 - `npm run homey:validate` — Homey validation at publish level; may
   rewrite files (locales), re-stage if it does.
 - `npm run homey:start` — `homey app run --remote` for on-device testing.
@@ -101,10 +96,14 @@ to judge success.
   `fireAndForget`). `scripts/bundle.mjs` stamps every local asset
   reference — only inside an attribute/import context, never a comment —
   with a content hash (`?v=`): phone webviews cache assets across app
-  versions. NEVER load the bundle as an ES module: `import()` failed to
-  fetch on Android and a static `<script type=module>` spun every webview
-  forever on a cold open (both shipped and reverted in com.melcloud —
-  see its CLAUDE.md). Phone webviews also cache the HTML ITSELF across
+  versions. Never load the bundle as a STATIC `<script type=module>`:
+  it stalls the whole boot on a cold open (shipped and reverted in
+  com.melcloud, proven on-device there). Dynamic `import()` is merely
+  unnecessary, not broken — its supposed Android fetch failures were
+  com.melcloud #1404's missing-bundle 404s — but do not churn the
+  loading mechanism without new on-device evidence: classic `defer`
+  carries the bounded boot plus beacon. Phone webviews also cache the
+  HTML ITSELF across
   app versions (proven on com.melcloud), so shipped bundle filenames are
   a COMPAT CONTRACT: `scripts/bundle.mjs` builds the entry twice —
   `index.js` (IIFE) for the current HTML, `index.mjs` (ESM) for every

--- a/api.mts
+++ b/api.mts
@@ -110,6 +110,15 @@ const api = {
         sensor1.capabilityName.localeCompare(sensor2.capabilityName),
       )
   },
+  logWebviewBoot: ({
+    body,
+    homey: { app },
+  }: {
+    body: unknown
+    homey: Homey
+  }): void => {
+    app.error('Settings webview boot failed:', JSON.stringify(body))
+  },
 }
 
 export default api

--- a/app.json
+++ b/app.json
@@ -16,6 +16,10 @@
     "getTemperatureSensors": {
       "method": "GET",
       "path": "/devices/sensors/temperature"
+    },
+    "logWebviewBoot": {
+      "method": "POST",
+      "path": "/boot-error"
     }
   },
   "author": {

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -14,17 +14,36 @@ import { build } from 'esbuild'
 // The IIFE global the page's inline `onHomeyReady` reads `start` from.
 const GLOBAL_NAME = 'MELCloudWebview'
 
-await build({
+const sharedOptions = {
   bundle: true,
   entryPoints: ['settings/index.mts'],
-  format: 'iife',
-  globalName: GLOBAL_NAME,
   legalComments: 'none',
   logLevel: 'info',
   minify: true,
-  outfile: 'settings/index.js',
   target: ['es2020'],
-})
+}
+
+// The entry builds TWICE. Phone webviews cache the HTML itself across app
+// versions (proven on com.melcloud: a cached dynamic-import HTML
+// requesting index.mjs against an app shipping only index.js → 404 →
+// "Loading failed"), so previously-shipped bundle filenames are a compat
+// contract: index.js serves the current classic-defer HTML, index.mjs
+// keeps every cached ESM-era HTML working (their import('./index.mjs')
+// finds the exported `start`). Never rename or drop a shipped bundle
+// filename — add alongside instead.
+await Promise.all([
+  build({
+    ...sharedOptions,
+    format: 'iife',
+    globalName: GLOBAL_NAME,
+    outfile: 'settings/index.js',
+  }),
+  build({
+    ...sharedOptions,
+    format: 'esm',
+    outfile: 'settings/index.mjs',
+  }),
+])
 
 // Cache-bust the static references: the phone webviews cache settings
 // assets across app versions, so a content hash per file forces a refetch

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,18 +1,23 @@
-// Bundles the settings page into a single self-contained CLASSIC script
-// served statically by Homey, inlining npm dependencies (temporal-polyfill)
-// so the webview works offline with versions pinned by the lockfile. The
-// output is an IIFE (format: 'iife') exposing `start` on a global, loaded
-// via a plain `<script src>` — NOT an ES module. Module fetches (`import()`
-// / `<script type=module>`) stall on a cold webview open against Homey's
-// local origin (#1404); classic resource fetches, like the stylesheet,
-// load cold.
+// Bundles the settings page into `.homeybuild`, the packaged app the
+// Homey CLI assembles: the CLI copies the app first and only then runs
+// `npm run build`, so anything emitted into the source tree lands too
+// late to ship (the com.melcloud #1404 root cause). Outputs stay a
+// compat pair — index.js (IIFE) for the current classic-defer HTML,
+// index.mjs (ESM) for cached ESM-era HTMLs — and npm dependencies
+// (temporal-polyfill) are inlined so the webview works offline with
+// versions pinned by the lockfile.
 import { createHash } from 'node:crypto'
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
 
 import { build } from 'esbuild'
 
 // The IIFE global the page's inline `onHomeyReady` reads `start` from.
 const GLOBAL_NAME = 'MELCloudWebview'
+
+// The Homey CLI's packaging target: `tsc` already emits here (its
+// validated `outDir`), and the CLI packs exactly this directory.
+const OUT_ROOT = '.homeybuild'
 
 const sharedOptions = {
   bundle: true,
@@ -23,56 +28,70 @@ const sharedOptions = {
   target: ['es2020'],
 }
 
-// The entry builds TWICE. Phone webviews cache the HTML itself across app
-// versions (proven on com.melcloud: a cached dynamic-import HTML
-// requesting index.mjs against an app shipping only index.js → 404 →
-// "Loading failed"), so previously-shipped bundle filenames are a compat
-// contract: index.js serves the current classic-defer HTML, index.mjs
-// keeps every cached ESM-era HTML working (their import('./index.mjs')
-// finds the exported `start`). Never rename or drop a shipped bundle
-// filename — add alongside instead.
 await Promise.all([
   build({
     ...sharedOptions,
     format: 'iife',
     globalName: GLOBAL_NAME,
-    outfile: 'settings/index.js',
+    outfile: path.join(OUT_ROOT, 'settings/index.js'),
   }),
   build({
     ...sharedOptions,
     format: 'esm',
-    outfile: 'settings/index.mjs',
+    outfile: path.join(OUT_ROOT, 'settings/index.mjs'),
   }),
 ])
 
-// Cache-bust the static references: the phone webviews cache settings
-// assets across app versions, so a content hash per file forces a refetch
-// exactly when a file changes.
-const hashOf = async (path) => {
-  const content = await readFile(path)
+// Courtesy cleanup: builds predating the `.homeybuild` emission left
+// bundles in the source tree. The CLI would copy them into the package,
+// where this build immediately overwrites them — harmless, but they
+// linger confusingly in the working tree.
+await Promise.all(
+  ['settings/index.js', 'settings/index.mjs'].map(async (file) =>
+    rm(file, { force: true }),
+  ),
+)
+
+// Cache-bust the PACKAGED page: phone webviews cache assets across app
+// versions, so a content hash per file forces a refetch exactly when a
+// file changes. The committed source HTML stays unstamped — `?v=` is a
+// package-time transform of the `.homeybuild` copy, which exists in the
+// CLI flow (its pre-process copy runs before `npm run build`) and is
+// absent in a standalone suite run, which only proves the bundles
+// compile.
+const hashOf = async (filePath) => {
+  const content = await readFile(filePath)
   return createHash('sha256').update(content).digest('hex').slice(0, 8)
 }
 
-const htmlPath = 'settings/index.html'
-const html = await readFile(htmlPath, 'utf8')
-// A local asset reference: an attribute value (href/src) or a dynamic
-// import specifier, with an optional existing stamp.
-const reference =
-  /(href="|src="|import\('\.\/)([^"':?/][^"':?]*)(?:\?v=[0-9a-f]+)?(["')])/gu
-// Hash each referenced asset up front — the replace below is sync.
-const hashes = new Map()
-for (const [, , file] of html.matchAll(reference)) {
-  if (!hashes.has(file)) {
-    hashes.set(file, await hashOf(`settings/${file}`))
-  }
+const htmlPath = path.join(OUT_ROOT, 'settings/index.html')
+let html = ''
+try {
+  html = await readFile(htmlPath, 'utf8')
+} catch {
+  html = ''
 }
-// Stamp only within a reference context, so the same filename written
-// elsewhere (e.g. a comment) is never rewritten.
-const stamped = html.replaceAll(
-  reference,
-  (_match, prefix, file, suffix) =>
-    `${prefix}${file}?v=${hashes.get(file)}${suffix}`,
-)
-if (stamped !== html) {
-  await writeFile(htmlPath, stamped)
+if (html !== '') {
+  const directory = path.dirname(htmlPath)
+  // A local asset reference: an attribute value (href/src) or a dynamic
+  // import specifier, with an optional existing stamp.
+  const reference =
+    /(href="|src="|import\('\.\/)([^"':?/][^"':?]*)(?:\?v=[0-9a-f]+)?(["')])/gu
+  // Hash each referenced asset up front — the replace below is sync.
+  const hashes = new Map()
+  for (const [, , file] of html.matchAll(reference)) {
+    if (!hashes.has(file)) {
+      hashes.set(file, await hashOf(path.join(directory, file)))
+    }
+  }
+  // Stamp only within a reference context, so the same filename written
+  // elsewhere (e.g. a comment) is never rewritten.
+  const stamped = html.replaceAll(
+    reference,
+    (_match, prefix, file, suffix) =>
+      `${prefix}${file}?v=${hashes.get(file)}${suffix}`,
+  )
+  if (stamped !== html) {
+    await writeFile(htmlPath, stamped)
+  }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -6,14 +6,15 @@
         <title>MELCloud Extension Settings</title>
         <script>
             // The page bundle loads as a classic defer script, not an ES
-            // module: module fetches (import()/type=module) stall on a
-            // cold webview open against Homey's local origin (the #1404
-            // spinner), while classic resource fetches — like the
-            // stylesheet — load cold. defer runs it after <body> parses
-            // (so the entry's top-level DOM lookups are safe) and before
-            // onHomeyReady; the poll then hands the instance to the
-            // bundle's start, or the timeout ends the overlay if it
-            // failed to load.
+            // module: a static module script stalls the whole boot on a
+            // cold webview open (a stalled module fetch also blocks
+            // onHomeyReady — proven on-device on com.melcloud), while
+            // classic scripts, like the stylesheet, load cold. defer runs
+            // it after <body> parses (so the entry's top-level DOM
+            // lookups are safe) and before onHomeyReady; the poll keeps
+            // the boot bounded — it hands the instance to the bundle's
+            // start, or reports why and ends the overlay if it failed to
+            // load.
             function onHomeyReady(homey) {
                 const deadline = Date.now() + 10000
                 const waitForBundle = () => {
@@ -41,8 +42,8 @@
                 waitForBundle()
             }
         </script>
-        <link href="styles.css?v=364176a1" rel="stylesheet">
-        <script defer src="index.js?v=f0e64b85"></script>
+        <link href="styles.css" rel="stylesheet">
+        <script defer src="index.js"></script>
         <script data-origin="settings" defer src="/homey.js"></script>
         <meta content="MELCloud extension settings" name="description">
     </head>

--- a/settings/index.html
+++ b/settings/index.html
@@ -20,8 +20,20 @@
                     if (globalThis.MELCloudWebview) {
                         globalThis.MELCloudWebview.start(homey)
                     } else if (Date.now() > deadline) {
-                        homey.ready()
-                        homey.alert(homey.__('settings.loadFailed')).catch(() => {})
+                        // Boot beacon: the bundle never booted — report WHY
+                        // before degrading. A 200 probe with no global means
+                        // the script fetched but failed to parse/run (old
+                        // engine); a probe error means the fetch itself
+                        // fails on this device.
+                        const script = document.querySelector('script[src*="index.js"]')
+                        const report = (probe) => {
+                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent }, () => {})
+                            homey.ready()
+                            homey.alert(homey.__('settings.loadFailed')).catch(() => {})
+                        }
+                        fetch(script ? script.src : 'index.js')
+                            .then((response) => { report('fetch ' + String(response.status)) })
+                            .catch((error) => { report('fetch failed: ' + String(error)) })
                     } else {
                         setTimeout(waitForBundle, 50)
                     }

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -72,6 +72,19 @@ const createHomeyContext = ({
 }
 
 describe('api', () => {
+  describe('logWebviewBoot', () => {
+    it('should log the boot failure body via app.error', () => {
+      const { homey } = createHomeyContext({
+        melcloudDevices: [],
+        temperatureSensors: [],
+      })
+
+      api.logWebviewBoot({ body: { message: 'boom' }, homey })
+
+      expect(homey.app.error).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('getLanguage', () => {
     it('should return the Homey language', () => {
       const { homey } = createHomeyContext({


### PR DESCRIPTION
## Full parity with com.melcloud (45.2.8 → 45.2.11 line), in one PR

| com.melcloud | Ici |
|---|---|
| Compat dual-build `index.js` (IIFE) + `index.mjs` (ESM, cached-HTML contract) — #1421 | ✓ |
| Boot beacon v2 (timeout → `userAgent` + fetch probe → restored `/boot-error`) — #1421 | ✓ |
| Publish pipeline fixed (the CLI's post-copy `npm run build` is the packager) — #1422 | ✓ |
| Corrected loader causality (static = proven broken; `import()` = merely unnecessary; 404 root cause) — #1423 | ✓ |
| **Design 2**: emission into `.homeybuild`, package-time `?v=` stamping, unstamped source HTML, no pre-build anywhere, post-pack assert (bundles + stamped page) — #1424 | ✓ |

Also restores the compat+beacon commit lost to the #1191 merge race.

## Verified (file-level)

- Full suite green; `homey:validate` exercises copy→build→stamp on every run.
- **Pristine clone + `npm ci` + one `homey app build`**: `.homeybuild` gets 2/2 bundles + a stamped page; the source tree gets zero artifacts; stamps byte-reproducible (`index.js?v=f0e64b85`).
- Dev-install through the plain CLI wrapper: success.

Still the unreleased **24.7.3**. **Merge → tag `v24.7.3`** → first extension store package with its settings bundle since the esbuild migration, under the post-pack assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
