### PR TITLE
fix: post-churn audit — es2020-safe settings bundle, resilient async paths, CSS tokens

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -331,5 +331,20 @@
     "pl": "Sekcja konfiguracji znajduje się teraz na górze ustawień i można ją zwijać — otwiera się zwinięta, gdy regulacja jest już włączona.",
     "ru": "Раздел конфигурации теперь находится вверху настроек и сворачивается — при открытии он свёрнут, если регулировка уже включена.",
     "sv": "Konfigurationsavsnittet ligger nu överst i inställningarna och är hopfällbart — det öppnas hopfällt när justeringen redan är aktiverad."
+  },
+  "24.7.5": {
+    "ar": "صفحة إعدادات أكثر موثوقية: ألوان تتكيف مع الوضع الداكن، وأزرار تُعطَّل بشكل أصلي، وسجل محفوظ لا يختفي، ومقاومة أفضل للأخطاء العابرة.",
+    "da": "Mere robust indstillingsside: farver der tilpasser sig mørk tilstand, native deaktiverede knapper, en historik der ikke forsvinder og bedre modstand mod forbigående fejl.",
+    "de": "Zuverlässigere Einstellungsseite: Farben passen sich dem Dunkelmodus an, nativ deaktivierte Schaltflächen, ein Verlauf, der nicht verschwindet, und bessere Widerstandsfähigkeit gegen vorübergehende Fehler.",
+    "en": "More reliable settings page: colors adapt to dark mode, natively disabled buttons, a log history that no longer disappears, and better resilience to transient failures.",
+    "es": "Página de ajustes más fiable: colores que se adaptan al modo oscuro, botones desactivados de forma nativa, un historial que ya no desaparece y mejor resistencia a fallos transitorios.",
+    "fr": "Page de réglages plus fiable : couleurs adaptées au mode sombre, boutons désactivés nativement, un historique qui ne disparaît plus, et une meilleure résistance aux erreurs passagères.",
+    "it": "Pagina delle impostazioni più affidabile: colori che si adattano alla modalità scura, pulsanti disabilitati nativamente, una cronologia che non scompare più e maggiore resilienza agli errori transitori.",
+    "ko": "더 안정적인 설정 페이지: 다크 모드에 맞는 색상, 기본 비활성화 버튼, 사라지지 않는 기록, 일시적인 오류에 대한 향상된 복원력.",
+    "nl": "Betrouwbaardere instellingenpagina: kleuren passen zich aan de donkere modus aan, native uitgeschakelde knoppen, een geschiedenis die niet meer verdwijnt en betere bestendigheid tegen tijdelijke fouten.",
+    "no": "Mer pålitelig innstillingsside: farger som tilpasser seg mørk modus, native deaktiverte knapper, en historikk som ikke forsvinner og bedre motstandskraft mot forbigående feil.",
+    "pl": "Bardziej niezawodna strona ustawień: kolory dostosowane do trybu ciemnego, natywnie wyłączane przyciski, historia, która już nie znika, i większa odporność na przejściowe błędy.",
+    "ru": "Более надёжная страница настроек: цвета адаптируются к тёмной теме, кнопки отключаются нативно, история больше не исчезает, повышена устойчивость к временным сбоям.",
+    "sv": "Mer tillförlitlig inställningssida: färger som anpassar sig till mörkt läge, nativt inaktiverade knappar, en historik som inte längre försvinner och bättre motståndskraft mot tillfälliga fel."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -194,5 +194,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.4"
+  "version": "24.7.5"
 }

--- a/.homeycompose/locales/ar.json
+++ b/.homeycompose/locales/ar.json
@@ -17,7 +17,6 @@
     "thermostatMode": "الوضع"
   },
   "settings": {
-    "allDevices": "جميع الأجهزة",
     "autoAdjust": "ضبط درجة حرارة مكيف الهواء تلقائيًا",
     "boolean": {
       "false": "لا",

--- a/.homeycompose/locales/da.json
+++ b/.homeycompose/locales/da.json
@@ -17,7 +17,6 @@
     "thermostatMode": "tilstanden"
   },
   "settings": {
-    "allDevices": "Alle enheder",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
       "false": "Nej",

--- a/.homeycompose/locales/de.json
+++ b/.homeycompose/locales/de.json
@@ -17,7 +17,6 @@
     "thermostatMode": "der Modus"
   },
   "settings": {
-    "allDevices": "Alle Geräte",
     "autoAdjust": "Temperatur der Klimaanlage automatisch anpassen",
     "boolean": {
       "false": "Nein",

--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -17,7 +17,6 @@
     "thermostatMode": "the mode"
   },
   "settings": {
-    "allDevices": "All devices",
     "autoAdjust": "Auto-adjust air conditioning temperature",
     "boolean": {
       "false": "No",

--- a/.homeycompose/locales/es.json
+++ b/.homeycompose/locales/es.json
@@ -17,7 +17,6 @@
     "thermostatMode": "el modo"
   },
   "settings": {
-    "allDevices": "Todos los dispositivos",
     "autoAdjust": "Autoajustar la temperatura del aire acondicionado",
     "boolean": {
       "false": "No",

--- a/.homeycompose/locales/fr.json
+++ b/.homeycompose/locales/fr.json
@@ -17,7 +17,6 @@
     "thermostatMode": "le mode"
   },
   "settings": {
-    "allDevices": "Tous les appareils",
     "autoAdjust": "Auto-ajuster la température de la climatisation",
     "boolean": {
       "false": "Non",

--- a/.homeycompose/locales/it.json
+++ b/.homeycompose/locales/it.json
@@ -17,7 +17,6 @@
     "thermostatMode": "la modalità"
   },
   "settings": {
-    "allDevices": "Tutti i dispositivi",
     "autoAdjust": "Regola automaticamente la temperatura del climatizzatore",
     "boolean": {
       "false": "No",

--- a/.homeycompose/locales/ko.json
+++ b/.homeycompose/locales/ko.json
@@ -17,7 +17,6 @@
     "thermostatMode": "모드"
   },
   "settings": {
-    "allDevices": "모든 장치",
     "autoAdjust": "에어컨 온도 자동 조절",
     "boolean": {
       "false": "아니요",

--- a/.homeycompose/locales/nl.json
+++ b/.homeycompose/locales/nl.json
@@ -17,7 +17,6 @@
     "thermostatMode": "de modus"
   },
   "settings": {
-    "allDevices": "Alle apparaten",
     "autoAdjust": "Auto-afstellen airco-temperatuur",
     "boolean": {
       "false": "Nee",

--- a/.homeycompose/locales/no.json
+++ b/.homeycompose/locales/no.json
@@ -17,7 +17,6 @@
     "thermostatMode": "modus"
   },
   "settings": {
-    "allDevices": "Alle enheter",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
       "false": "Nei",

--- a/.homeycompose/locales/pl.json
+++ b/.homeycompose/locales/pl.json
@@ -17,7 +17,6 @@
     "thermostatMode": "tryb"
   },
   "settings": {
-    "allDevices": "Wszystkie urządzenia",
     "autoAdjust": "Automatycznie dostosowuj temperaturę klimatyzacji",
     "boolean": {
       "false": "Nie",

--- a/.homeycompose/locales/ru.json
+++ b/.homeycompose/locales/ru.json
@@ -17,7 +17,6 @@
     "thermostatMode": "режим"
   },
   "settings": {
-    "allDevices": "Все устройства",
     "autoAdjust": "Автоматически регулировать температуру кондиционера",
     "boolean": {
       "false": "Нет",

--- a/.homeycompose/locales/sv.json
+++ b/.homeycompose/locales/sv.json
@@ -17,7 +17,6 @@
     "thermostatMode": "läget"
   },
   "settings": {
-    "allDevices": "Alla enheter",
     "autoAdjust": "Autojustera luftkonditioneringstemperaturen",
     "boolean": {
       "false": "Nej",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,9 +162,10 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
   until the rule passes. One counterweight: when every compliant shape
   reads worse than the violation (a rule-pair conflict, a
   protocol-imposed form), the documented disable IS the honest form.
-  Current irreducibles: the fire-and-forget rule trio
-  (`lib/fire-and-forget.mts`, settings copy) and the TS9019
-  isolatedDeclarations carve-out in `lib/homey.mts`.
+  Current irreducibles: the fire-and-forget disable (once, in
+  `lib/fire-and-forget.mts` — the settings page wraps it for its
+  default `onError`) and the TS9019 isolatedDeclarations carve-out in
+  `lib/homey.mts`.
 - Naming is stricter than com.melcloud: properties are camelCase-only
   in app code. The tests block relaxes it (documented in the config)
   because test doubles mirror external contracts: capability ids

--- a/app.json
+++ b/app.json
@@ -195,5 +195,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.4"
+  "version": "24.7.5"
 }

--- a/app.mts
+++ b/app.mts
@@ -81,7 +81,11 @@ export default class MELCloudExtensionApp extends App {
 
   readonly #melcloudDevices: HomeyAPIV3Local.ManagerDevices.Device[] = []
 
-  readonly #sources = new Map<string, OutdoorSource>()
+  // Keyed by source path, memoizing the IN-FLIGHT creation (not the
+  // result): devices of one building fan out concurrently and must
+  // share a single watcher per sensor, so the promise lands in the map
+  // synchronously, before the first await.
+  readonly #sources = new Map<string, Promise<OutdoorSource>>()
 
   readonly #temperatureSensors: HomeyAPIV3Local.ManagerDevices.Device[] = []
 
@@ -195,9 +199,16 @@ export default class MELCloudExtensionApp extends App {
       this.#deviceListeners.map(async (listener) => listener.destroy()),
     )
     this.#deviceListeners.length = 0
-    for (const source of this.#sources.values()) {
-      source.destroy()
-    }
+    await Promise.all(
+      this.#sources.values().map(async (source) => {
+        try {
+          const settled = await source
+          settled.destroy()
+        } catch {
+          // A source that never materialized has nothing to destroy.
+        }
+      }),
+    )
     this.#sources.clear()
   }
 
@@ -216,10 +227,19 @@ export default class MELCloudExtensionApp extends App {
     if (existing !== undefined) {
       return existing
     }
-    const source =
-      sourcePath === null ?
-        new WeatherOutdoorSource(this)
-      : await CapabilityOutdoorSource.create(this, sourcePath)
+    const source = (async (): Promise<OutdoorSource> => {
+      if (sourcePath === null) {
+        return new WeatherOutdoorSource(this)
+      }
+      try {
+        return await CapabilityOutdoorSource.create(this, sourcePath)
+      } catch (error) {
+        // A failed creation must not stay cached: the next lookup
+        // retries.
+        this.#sources.delete(key)
+        throw error
+      }
+    })()
     this.#sources.set(key, source)
     return source
   }
@@ -232,12 +252,21 @@ export default class MELCloudExtensionApp extends App {
   }
 
   // Debounces device list reload: rapid device.create/delete events
-  // are coalesced into a single init after INIT_DELAY.
+  // are coalesced into a single init after INIT_DELAY. The timer body
+  // routes through fireAndForget: the SDK invokes it bare, so a
+  // rejection would otherwise terminate the app process.
   #init(): void {
     this.homey.clearTimeout(this.#initTimeout)
-    this.#initTimeout = this.homey.setTimeout(async () => {
-      await this.#loadDevices()
-      await this.autoAdjustCooling()
+    this.#initTimeout = this.homey.setTimeout(() => {
+      fireAndForget(
+        (async (): Promise<void> => {
+          await this.#loadDevices()
+          await this.autoAdjustCooling()
+        })(),
+        (error) => {
+          this.error(getErrorMessage(error))
+        },
+      )
     }, INIT_DELAY)
   }
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -54,7 +54,9 @@ const config = defineConfig([
     ignores: [
       '.homeybuild/',
       'coverage/',
-      // esbuild output (see scripts/bundle.mjs), also gitignored
+      // Stale local bundle from builds predating the `.homeybuild`
+      // emission (bundle.mjs deletes it on its next run); without the
+      // entry a never-rebuilt tree would get swept by lint.
       'settings/index.mjs',
     ],
   },
@@ -863,13 +865,19 @@ const config = defineConfig([
   {
     files: ['lib/homey.mts'],
     rules: {
+      // The homey SDK is runtime-provided by the platform, deliberately
+      // absent from package.json dependencies.
       'import-x/no-extraneous-dependencies': 'off',
+      // `Homey.App` member access is the CJS-interop-safe documented
+      // form of the SDK's `export =` default.
       'import-x/no-named-as-default-member': 'off',
     },
   },
   {
     files: ['**/api.mts', 'app.mts'],
     rules: {
+      // The Homey SDK loads the app and its api surface as default
+      // exports.
       'import-x/no-default-export': 'off',
       'import-x/prefer-default-export': [
         'error',
@@ -882,7 +890,10 @@ const config = defineConfig([
   {
     files: ['**/*.config.ts'],
     rules: {
+      // Config objects carry external schema keys (rule ids, tool
+      // options) that no naming convention governs.
       '@typescript-eslint/naming-convention': 'off',
+      // Config loaders consume default exports.
       'import-x/no-default-export': 'off',
       'import-x/prefer-default-export': [
         'error',
@@ -1112,11 +1123,14 @@ const config = defineConfig([
           selector: 'typeParameter',
         },
       ],
+      // Fixtures and assertions are literal-heavy by nature.
       '@typescript-eslint/no-magic-numbers': 'off',
       // Test doubles cast wholesale around the SDK's branded types.
       '@typescript-eslint/no-unsafe-type-assertion': 'off',
       // Owned by `vitest/unbound-method`, the mock-aware port.
       '@typescript-eslint/unbound-method': 'off',
+      // Suites are one `describe` per function — length caps target
+      // production code, not test tables.
       'max-lines-per-function': 'off',
       'max-statements': 'off',
       // Mock builders nest factories.

--- a/homey-api-override.d.ts
+++ b/homey-api-override.d.ts
@@ -33,8 +33,6 @@ declare module 'homey-api' {
 
       readonly max?: number
 
-      readonly min?: number
-
       readonly title: string
     }
 
@@ -59,7 +57,6 @@ declare module 'homey-api' {
       setCapabilityValue(options: {
         capabilityId: string
         value: boolean | number | string
-        opts?: { duration?: number }
       }): Promise<void>
     }
   }
@@ -70,10 +67,7 @@ declare module 'homey-api' {
 
       destroy(): void
 
-      setValue(
-        value: boolean | number | string,
-        options?: { duration?: number },
-      ): Promise<void>
+      setValue(value: boolean | number | string): Promise<void>
     }
   }
 }

--- a/listeners/capability-source.mts
+++ b/listeners/capability-source.mts
@@ -1,6 +1,8 @@
 import type { HomeyAPIV3Local } from 'homey-api'
 
 import type MELCloudExtensionApp from '../app.mts'
+import { fireAndForget } from '../lib/fire-and-forget.mts'
+import { getErrorMessage } from '../lib/get-error-message.mts'
 import { ListenerError } from './error.mts'
 import { OutdoorSource } from './outdoor-source.mts'
 
@@ -63,9 +65,16 @@ export class CapabilityOutdoorSource extends OutdoorSource {
         deviceId: this.#device.id,
       }),
     )
+    // homey-api invokes the listener bare: route it through
+    // fireAndForget so a failed recalculation logs instead of crashing
+    // the app with an unhandled rejection.
     this.#capabilityInstance = this.#device.makeCapabilityInstance(
       this.#capabilityId,
-      async (value) => this.update(value),
+      (value) => {
+        fireAndForget(this.update(value), (error) => {
+          this.app.error(getErrorMessage(error))
+        })
+      },
     )
     this.app.pushToUI('created', {
       capability: this.app.names.temperature,

--- a/listeners/melcloud.mts
+++ b/listeners/melcloud.mts
@@ -2,7 +2,9 @@ import type { HomeyAPIV3Local } from 'homey-api'
 
 import type MELCloudExtensionApp from '../app.mts'
 import type { Names, Thresholds } from '../types.mts'
+import { fireAndForget } from '../lib/fire-and-forget.mts'
 import { formatTemperature } from '../lib/format-temperature.mts'
+import { getErrorMessage } from '../lib/get-error-message.mts'
 import type { OutdoorSource } from './outdoor-source.mts'
 
 const COOL = 'cool'
@@ -69,20 +71,31 @@ export class MELCloudListener {
   public async listenToThermostatMode(): Promise<void> {
     const currentThermostatMode =
       await this.#getCapabilityValue(THERMOSTAT_MODE)
+    // homey-api invokes capability listeners bare: route the async
+    // bodies through fireAndForget so a failure (e.g. the device going
+    // offline mid-update) logs instead of crashing the app with an
+    // unhandled rejection.
     this.#thermostatModeListener = this.#device.makeCapabilityInstance(
       THERMOSTAT_MODE,
-      async (value) => {
-        this.#app.pushToUI('listened', {
-          capability: this.#names.thermostatMode,
-          name: this.#device.name,
-          value,
-        })
-        if (value === COOL) {
-          await this.#listenToTargetTemperature()
-          return
-        }
-        await this.#destroyTemperature()
-        this.#source.detach(this)
+      (value) => {
+        fireAndForget(
+          (async (): Promise<void> => {
+            this.#app.pushToUI('listened', {
+              capability: this.#names.thermostatMode,
+              name: this.#device.name,
+              value,
+            })
+            if (value === COOL) {
+              await this.#listenToTargetTemperature()
+              return
+            }
+            await this.#destroyTemperature()
+            this.#source.detach(this)
+          })(),
+          (error) => {
+            this.#app.error(getErrorMessage(error))
+          },
+        )
       },
     )
     this.#app.pushToUI('created', {
@@ -174,7 +187,7 @@ export class MELCloudListener {
     )
     this.#targetTemperatureListener = this.#device.makeCapabilityInstance(
       TARGET_TEMPERATURE,
-      async (value) => {
+      (value) => {
         if (value === this.#getTargetTemperature()) {
           return
         }
@@ -183,7 +196,9 @@ export class MELCloudListener {
           name: this.#device.name,
           value: formatTemperature(value),
         })
-        await this.#setThreshold(Number(value))
+        fireAndForget(this.#setThreshold(Number(value)), (error) => {
+          this.#app.error(getErrorMessage(error))
+        })
       },
     )
     this.#app.pushToUI('created', {

--- a/listeners/outdoor-source.mts
+++ b/listeners/outdoor-source.mts
@@ -33,7 +33,19 @@ export abstract class OutdoorSource {
 
   public async attach(listener: MELCloudListener): Promise<void> {
     this.#subscribers.add(listener)
-    this.#watching ??= this.start()
+    // A failed start must not stay cached: reset the single-flight
+    // guard (and drop the subscriber this attach added) so the next
+    // attach retries watching instead of re-awaiting the same
+    // rejection forever.
+    this.#watching ??= (async (): Promise<void> => {
+      try {
+        await this.start()
+      } catch (error) {
+        this.#watching = null
+        this.#subscribers.delete(listener)
+        throw error
+      }
+    })()
     await this.#watching
   }
 

--- a/listeners/weather-source.mts
+++ b/listeners/weather-source.mts
@@ -1,4 +1,5 @@
 import type MELCloudExtensionApp from '../app.mts'
+import { fireAndForget } from '../lib/fire-and-forget.mts'
 import { getErrorMessage } from '../lib/get-error-message.mts'
 import { OutdoorSource } from './outdoor-source.mts'
 
@@ -32,8 +33,18 @@ export class WeatherOutdoorSource extends OutdoorSource {
 
   protected async start(): Promise<void> {
     this.initialize(await this.#fetchTemperature())
-    this.#pollInterval = this.app.homey.setInterval(async () => {
-      await this.update(await this.#fetchTemperature())
+    // The SDK invokes the timer callback bare: route the poll through
+    // fireAndForget so a transient weather failure logs instead of
+    // crashing the app with an unhandled rejection.
+    this.#pollInterval = this.app.homey.setInterval(() => {
+      fireAndForget(
+        (async (): Promise<void> => {
+          await this.update(await this.#fetchTemperature())
+        })(),
+        (error) => {
+          this.app.error(getErrorMessage(error))
+        },
+      )
     }, POLL_INTERVAL)
     this.app.pushToUI('created', {
       capability: this.app.names.temperature,

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -17,7 +17,6 @@
     "thermostatMode": "الوضع"
   },
   "settings": {
-    "allDevices": "جميع الأجهزة",
     "autoAdjust": "ضبط درجة حرارة مكيف الهواء تلقائيًا",
     "boolean": {
       "false": "لا",

--- a/locales/da.json
+++ b/locales/da.json
@@ -17,14 +17,11 @@
     "homeyWeather": "Homey-vejret"
   },
   "settings": {
-    "allDevices": "Alle enheder",
-    "apply": "Anvend på alle luft-til-luft enheder",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
       "false": "Nej",
       "true": "Ja"
     },
-    "capabilities": "Udendørstemperatur",
     "configuration": "Konfiguration",
     "defaultSource": "Homey-vejr",
     "disabledSource": "Juster ikke",

--- a/locales/de.json
+++ b/locales/de.json
@@ -17,7 +17,6 @@
     "thermostatMode": "der Modus"
   },
   "settings": {
-    "allDevices": "Alle Geräte",
     "autoAdjust": "Temperatur der Klimaanlage automatisch anpassen",
     "boolean": {
       "false": "Nein",

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,14 +17,11 @@
     "homeyWeather": "the Homey weather"
   },
   "settings": {
-    "allDevices": "All devices",
-    "apply": "Apply to all air-to-air devices",
     "autoAdjust": "Auto-adjust air conditioning temperature",
     "boolean": {
       "false": "No",
       "true": "Yes"
     },
-    "capabilities": "Outdoor temperature",
     "configuration": "Configuration",
     "defaultSource": "Homey weather",
     "disabledSource": "Do not adjust",

--- a/locales/es.json
+++ b/locales/es.json
@@ -17,14 +17,11 @@
     "homeyWeather": "el tiempo de Homey"
   },
   "settings": {
-    "allDevices": "Todos los dispositivos",
-    "apply": "Aplicar a todos los dispositivos aire-aire",
     "autoAdjust": "Autoajustar la temperatura del aire acondicionado",
     "boolean": {
       "false": "No",
       "true": "Sí"
     },
-    "capabilities": "Temperatura exterior",
     "configuration": "Configuración",
     "defaultSource": "Tiempo de Homey",
     "disabledSource": "No ajustar",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -17,14 +17,11 @@
     "homeyWeather": "la météo Homey"
   },
   "settings": {
-    "allDevices": "Tous les appareils",
-    "apply": "Appliquer à tous les appareils air-air",
     "autoAdjust": "Auto-ajuster la température de la climatisation",
     "boolean": {
       "false": "Non",
       "true": "Oui"
     },
-    "capabilities": "Température extérieure",
     "configuration": "Configuration",
     "defaultSource": "Météo Homey",
     "disabledSource": "Ne pas activer",

--- a/locales/it.json
+++ b/locales/it.json
@@ -17,7 +17,6 @@
     "thermostatMode": "la modalità"
   },
   "settings": {
-    "allDevices": "Tutti i dispositivi",
     "autoAdjust": "Regola automaticamente la temperatura del climatizzatore",
     "boolean": {
       "false": "No",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -17,7 +17,6 @@
     "thermostatMode": "모드"
   },
   "settings": {
-    "allDevices": "모든 장치",
     "autoAdjust": "에어컨 온도 자동 조절",
     "boolean": {
       "false": "아니요",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -17,14 +17,11 @@
     "homeyWeather": "het Homey-weer"
   },
   "settings": {
-    "allDevices": "Alle apparaten",
-    "apply": "Toepassen op alle lucht-lucht apparaten",
     "autoAdjust": "Auto-afstellen airco-temperatuur",
     "boolean": {
       "false": "Nee",
       "true": "Ja"
     },
-    "capabilities": "Buitentemperatuur",
     "configuration": "Configuratie",
     "defaultSource": "Homey-weer",
     "disabledSource": "Niet aanpassen",

--- a/locales/no.json
+++ b/locales/no.json
@@ -17,14 +17,11 @@
     "homeyWeather": "Homey-været"
   },
   "settings": {
-    "allDevices": "Alle enheter",
-    "apply": "Bruk på alle luft-til-luft enheter",
     "autoAdjust": "Autojuster aircondition-temperaturen",
     "boolean": {
       "false": "Nei",
       "true": "Ja"
     },
-    "capabilities": "Utetemperatur",
     "configuration": "Konfigurasjon",
     "defaultSource": "Homey-vær",
     "disabledSource": "Ikke juster",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -17,7 +17,6 @@
     "thermostatMode": "tryb"
   },
   "settings": {
-    "allDevices": "Wszystkie urządzenia",
     "autoAdjust": "Automatycznie dostosowuj temperaturę klimatyzacji",
     "boolean": {
       "false": "Nie",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -17,7 +17,6 @@
     "thermostatMode": "режим"
   },
   "settings": {
-    "allDevices": "Все устройства",
     "autoAdjust": "Автоматически регулировать температуру кондиционера",
     "boolean": {
       "false": "Нет",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -17,14 +17,11 @@
     "homeyWeather": "Homey-vädret"
   },
   "settings": {
-    "allDevices": "Alla enheter",
-    "apply": "Tillämpa på alla luft-till-luft enheter",
     "autoAdjust": "Autojustera luftkonditioneringstemperaturen",
     "boolean": {
       "false": "Nej",
       "true": "Ja"
     },
-    "capabilities": "Utomhustemperatur",
     "configuration": "Konfiguration",
     "defaultSource": "Homey-väder",
     "disabledSource": "Justera inte",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.4",
+  "version": "24.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.7.4",
+      "version": "24.7.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.4",
+  "version": "24.7.5",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1,6 +1,8 @@
 import type Homey from 'homey/lib/HomeySettings'
 import { Temporal } from 'temporal-polyfill'
 
+import { fireAndForget as forget } from '../lib/fire-and-forget.mts'
+import { getErrorMessage } from '../lib/get-error-message.mts'
 import {
   type AdjustableDevice,
   type AdjustableGroup,
@@ -78,13 +80,14 @@ const surfaceError = (error: unknown): void => {
 /**
  * Runs an async operation that shouldn't block. Rejections go to `onError`
  * (default: `surfaceError`, which reports them in the webview dev tools).
+ * Thin default-argument wrapper over the shared lib helper — the
+ * bundler inlines the import, and the documented disable lives once.
  */
 const fireAndForget = (
   promise: Promise<unknown>,
   onError: (error: unknown) => void = surfaceError,
 ): void => {
-  // eslint-disable-next-line unicorn/prefer-await -- fire-and-forget: rejections route to onError without blocking the caller
-  promise.catch(onError)
+  forget(promise, onError)
 }
 
 // Promisifies Homey Settings API callbacks (error-first convention)
@@ -107,6 +110,11 @@ const getElement = <T extends HTMLElement>(
   elementType: string,
 ): T => {
   const element = document.querySelector(`#${id}`)
+  // Distinct diagnoses (com.melcloud form): a missing id must not read
+  // as a type mismatch.
+  if (element === null) {
+    throw new TypeError(`Element with id \`${id}\` not found`)
+  }
   if (!(element instanceof elementConstructor)) {
     throw new TypeError(`Element with id \`${id}\` is not a ${elementType}`)
   }
@@ -134,19 +142,6 @@ const refreshElement = getButtonElement('refresh')
 const enabledElement = getSelectElement('enabled')
 const configurationElement = getDetailsElement('configuration')
 
-// The style library sizes legends through the `legend` element, not the
-// class, so the summary cannot inherit the title scale — copy it from a
-// real legend at boot to stay in lockstep with whatever the library
-// ships (the stylesheet keeps a close fallback).
-const matchLegendScale = (): void => {
-  const legend = document.querySelector('legend.homey-form-legend')
-  const summary = document.querySelector('#configuration_summary')
-  if (legend !== null && summary instanceof HTMLElement) {
-    const { fontSize, fontWeight } = getComputedStyle(legend)
-    summary.style.fontSize = fontSize
-    summary.style.fontWeight = fontWeight
-  }
-}
 const logsElement = getDivElement('logs')
 const sourcesElement = getDivElement('sources')
 
@@ -187,10 +182,10 @@ const serializeState = (): string =>
 const busyState: { value: boolean } = { value: false }
 
 const updateDirty = (): void => {
-  applyElement.classList.toggle(
-    'is-disabled',
-    busyState.value || serializeState() === savedState.value,
-  )
+  // Native `disabled` (com.melcloud form): it also blocks keyboard
+  // activation mid-request and is announced by screen readers.
+  applyElement.disabled =
+    busyState.value || serializeState() === savedState.value
 }
 
 const resetSavedState = (): void => {
@@ -202,7 +197,7 @@ const resetSavedState = (): void => {
 // library's `is-loading` spinner shifts the label sideways.
 const setButtonsBusy = (areBusy: boolean): void => {
   busyState.value = areBusy
-  refreshElement.classList.toggle('is-disabled', areBusy)
+  refreshElement.disabled = areBusy
   updateDirty()
 }
 
@@ -337,13 +332,6 @@ const displayLog = (log: TimestampedLog): void => {
   logsElement.insertBefore(createDayElement(log.time), rowElement)
 }
 
-const getErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message
-  }
-  return typeof error === 'string' ? error : JSON.stringify(error)
-}
-
 // Only show logs from the last LOG_RETENTION_DAYS (midnight cutoff)
 const getOldestDisplayableInstant = (): Temporal.Instant =>
   Temporal.Now.zonedDateTimeISO()
@@ -351,10 +339,21 @@ const getOldestDisplayableInstant = (): Temporal.Instant =>
     .startOfDay()
     .toInstant()
 
+// One-shot flag, not a child-count guard: a live 'log' event landing
+// between listener wiring and the first settings fetch must not
+// suppress the whole retained history for the session.
+const retainedLogsState = { wereDisplayed: false }
+
 const displayRetainedLogs = (logs: readonly TimestampedLog[]): void => {
-  if (logsElement.childElementCount > 0) {
+  if (retainedLogsState.wereDisplayed) {
     return
   }
+  retainedLogsState.wereDisplayed = true
+  // Any live row displayed before this first fetch is also part of the
+  // retained list (the app persists before the fetch can answer):
+  // rebuild the pane from scratch — right order, no duplicates.
+  logsElement.replaceChildren()
+  topDay.value = null
   const oldestInstant = getOldestDisplayableInstant()
   const retainedLogs = logs
     .filter(
@@ -406,12 +405,16 @@ const fetchHomeySettings = async (homey: Homey): Promise<void> => {
 const isNotFound = (error: unknown): boolean =>
   getErrorMessage(error) === 'notFound'
 
-const fetchTemperatureSensors = async (
+// Shared GET-or-empty policy of the two device lists: a 404 (endpoint
+// absent — an older com.melcloud) silently reads as "none", any other
+// failure alerts and still degrades to an empty list.
+const fetchListOrEmpty = async <T,>(
   homey: Homey,
-): Promise<TemperatureSensor[]> => {
+  path: string,
+): Promise<T[]> => {
   try {
-    return await homeyCallback<TemperatureSensor[]>((callback) => {
-      homey.api('GET', '/devices/sensors/temperature', callback)
+    return await homeyCallback<T[]>((callback) => {
+      homey.api('GET', path, callback)
     })
   } catch (error) {
     if (!isNotFound(error)) {
@@ -421,20 +424,15 @@ const fetchTemperatureSensors = async (
   }
 }
 
+const fetchTemperatureSensors = async (
+  homey: Homey,
+): Promise<TemperatureSensor[]> =>
+  fetchListOrEmpty<TemperatureSensor>(homey, '/devices/sensors/temperature')
+
 const fetchAdjustableGroups = async (
   homey: Homey,
-): Promise<AdjustableGroup[]> => {
-  try {
-    return await homeyCallback<AdjustableGroup[]>((callback) => {
-      homey.api('GET', '/devices/groups', callback)
-    })
-  } catch (error) {
-    if (!isNotFound(error)) {
-      await homey.alert(getErrorMessage(error))
-    }
-    return []
-  }
-}
+): Promise<AdjustableGroup[]> =>
+  fetchListOrEmpty<AdjustableGroup>(homey, '/devices/groups')
 
 // Auto-enable when the user picks a different source (UX convenience)
 const enableAdjustment = (): void => {
@@ -738,11 +736,15 @@ const populateSources = async (homey: Homey): Promise<void> => {
   emptyElement.hidden = devices.length > 0
 }
 
+// Spread (not `.entries().map()`): iterator helpers are a 2025-era
+// runtime API, far above the webview's es2020 floor — esbuild lowers
+// syntax only, never runtime APIs.
 const getSelectedSources = (): OutdoorSources =>
   Object.fromEntries(
-    sourceSelections
-      .entries()
-      .map(([deviceId, value]) => [deviceId, value === '' ? null : value]),
+    [...sourceSelections].map(([deviceId, value]) => [
+      deviceId,
+      value === '' ? null : value,
+    ]),
   )
 
 const autoAdjustCooling = async (homey: Homey): Promise<void> =>
@@ -827,7 +829,6 @@ const reportInitFailure = (homey: Homey, error: unknown): void => {
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
 export const start = async (homey: Homey): Promise<void> => {
-  matchLegendScale()
   // Listeners before the data load: the Refresh button is the retry
   // affordance when the initial load fails or times out, so it must work
   // regardless of how `run` ends.

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -1,7 +1,3 @@
-.is-disabled {
-  pointer-events: none;
-}
-
 /* Shared two-column grid: every row's time cell takes the width of the
    longest one, so the messages align across rows whatever the relative
    time's length ("il y a 1 heure" vs "il y a 13 heures"). */
@@ -16,22 +12,33 @@
   display: contents;
 }
 
+/* Buttons disable natively during in-flight actions (com.melcloud
+   form): native `disabled` also blocks keyboard activation and is
+   announced by screen readers. */
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Homey Style Library tokens with today's hex as fallback: adaptive
+   when the injected sheet defines them (dark theme), byte-identical
+   otherwise. */
 .log-time {
-  color: #888;
+  color: var(--homey-color-text-light, #888);
   text-align: center;
   white-space: nowrap;
 }
 
 .log-message-calculated {
-  color: #008000;
+  color: var(--homey-color-green, #008000);
 }
 
 .log-message-error {
-  color: #e8000d;
+  color: var(--homey-color-text-danger, #e8000d);
 }
 
 .log-message-listened {
-  color: #0047ab;
+  color: var(--homey-color-highlight, #0047ab);
 }
 
 /* Two-column grid for button pairs */
@@ -72,7 +79,7 @@
    radius, a checkmark gutter — `overflow: auto` because the logical
    overflow-block is not supported by the phone webviews */
 .combobox-list {
-  background: #fff;
+  background: var(--homey-color-component, #fff);
   border-radius: 1em;
   box-shadow: 0 0.5em 2em rgb(0 0 0 / 20%);
   inset-block-start: calc(100% + 0.25em);
@@ -95,7 +102,7 @@
 }
 
 .combobox-option:hover {
-  background: #f2f2f2;
+  background: var(--homey-color-component-hover, #f2f2f2);
 }
 
 /* Thin stroke checkmark, same pen as the field chevron */
@@ -113,7 +120,7 @@
 }
 
 .log-day {
-  color: #888;
+  color: var(--homey-color-text-light, #888);
   font-weight: 600;
   grid-column: 1 / -1;
   padding-block: 0.5em;
@@ -121,10 +128,11 @@
 
 /* The collapsible configuration panel: the summary doubles as the
    fieldset legend, but Homey's style library sizes legends through the
-   `legend` element, not the class — restate the title scale here, plus
-   the click affordance a legend lacks. */
+   `legend` element, not the class — restate the legend's own tokens
+   (20px medium, bold — the old hardcoded 1.375rem sat 2px over it),
+   plus the click affordance a legend lacks. */
 summary.homey-form-legend {
   cursor: pointer;
-  font-size: 1.375rem;
-  font-weight: 700;
+  font-size: var(--homey-font-size-medium);
+  font-weight: var(--homey-font-weight-bold);
 }

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -40,9 +40,7 @@ export const createMockDevice = ({
   readonly id: string
   readonly name: string
   readonly capabilities?: readonly string[]
-  readonly capabilitiesOptions?: Readonly<
-    Record<string, { max?: number; min?: number }>
-  >
+  readonly capabilitiesOptions?: Readonly<Record<string, { max?: number }>>
   readonly melcloudId?: string
   readonly values?: Record<string, boolean | number | string | null>
 }): MockDevice => {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -335,6 +335,20 @@ describe(MELCloudExtensionApp, () => {
     })
   })
 
+  it('should log instead of crashing when the debounced reload fails', async () => {
+    const { classicDevice } = createDevices()
+    const { app, manager } = await createHarness([classicDevice])
+    await advancePastInit()
+    const createHandler = manager.eventHandlers.get('device.create')
+    assertDefined(createHandler)
+    manager.getDevices.mockRejectedValueOnce(new Error('api_down'))
+
+    createHandler()
+    await advancePastInit()
+
+    expect(app.error).toHaveBeenCalledWith('api_down')
+  })
+
   it('should coalesce rapid device events into one reload', async () => {
     const { classicDevice } = createDevices()
     const { manager } = await createHarness([classicDevice])

--- a/tests/unit/capability-source.test.ts
+++ b/tests/unit/capability-source.test.ts
@@ -15,6 +15,9 @@ const OUTDOOR_PATH = 'sensor-1:measure_temperature.outdoor'
 
 interface Harness {
   readonly app: MELCloudExtensionApp
+  readonly getCapabilityValue: ReturnType<
+    typeof createMockDevicesManager
+  >['getCapabilityValue']
   readonly pushToUI: ReturnType<typeof vi.fn>
   readonly sensorDevice: MockDevice
 }
@@ -27,14 +30,17 @@ const createHarness = (): Harness => {
     name: 'Outdoor unit',
     values: { 'measure_temperature.outdoor': 30 },
   })
-  const { manager } = createMockDevicesManager([sensorDevice])
+  const { getCapabilityValue, manager } = createMockDevicesManager([
+    sensorDevice,
+  ])
   const pushToUI = vi.fn<(name: string, params?: unknown) => void>()
   const app = mock<MELCloudExtensionApp>({
     api: { devices: manager },
+    error: vi.fn<(...args: unknown[]) => void>(),
     names,
     pushToUI,
   })
-  return { app, pushToUI, sensorDevice }
+  return { app, getCapabilityValue, pushToUI, sensorDevice }
 }
 
 const createSubscriber = (): MELCloudListener =>
@@ -140,6 +146,42 @@ describe(CapabilityOutdoorSource, () => {
     await getOutdoorInstance(harness).listener(30)
 
     expect(subscriber.setTargetTemperature).toHaveBeenCalledTimes(0)
+  })
+
+  it('should retry watching after a failed start', async () => {
+    const harness = createHarness()
+    const source = await CapabilityOutdoorSource.create(
+      harness.app,
+      OUTDOOR_PATH,
+    )
+    harness.getCapabilityValue.mockRejectedValueOnce(new Error('offline'))
+
+    // The failed start must not stay cached as the single-flight guard.
+    await expect(source.attach(createSubscriber())).rejects.toThrow('offline')
+
+    await source.attach(createSubscriber())
+
+    expect(source.value).toBe(30)
+  })
+
+  it('should log instead of crashing when a recalculation fails', async () => {
+    const harness = createHarness()
+    const source = await CapabilityOutdoorSource.create(
+      harness.app,
+      OUTDOOR_PATH,
+    )
+    const subscriber = createSubscriber()
+    await source.attach(subscriber)
+    vi.mocked(subscriber.setTargetTemperature).mockRejectedValueOnce(
+      new Error('offline'),
+    )
+
+    await getOutdoorInstance(harness).listener(38.4)
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    expect(harness.app.error).toHaveBeenCalledWith('offline')
   })
 
   it('should read a non-numeric payload as no measurement', async () => {

--- a/tests/unit/melcloud-listener.test.ts
+++ b/tests/unit/melcloud-listener.test.ts
@@ -69,6 +69,7 @@ const createHarness = ({
           ),
       },
     },
+    error: vi.fn<(...args: unknown[]) => void>(),
     homey: {
       settings: {
         get: (key: keyof HomeySettings): unknown => settingsStore[key] ?? null,
@@ -272,6 +273,30 @@ describe(MELCloudListener, () => {
       value: 23,
     })
     expect(harness.detach).toHaveBeenCalledWith(harness.listener)
+  })
+
+  it('should log instead of crashing when the mode-switch work fails', async () => {
+    const harness = createHarness({ thermostatMode: 'heat' })
+    await harness.listener.listenToThermostatMode()
+    harness.attach.mockRejectedValueOnce(new Error('offline'))
+
+    await getInstance(harness, 'thermostat_mode').listener('cool')
+    await settleListeners()
+
+    expect(harness.app.error).toHaveBeenCalledWith('offline')
+  })
+
+  it('should log instead of crashing when the threshold recalculation fails', async () => {
+    const harness = createHarness()
+    await harness.listener.listenToThermostatMode()
+    getInstance(harness, 'target_temperature').setValue.mockRejectedValueOnce(
+      new Error('offline'),
+    )
+
+    await getInstance(harness, 'target_temperature').listener(26)
+    await settleListeners()
+
+    expect(harness.app.error).toHaveBeenCalledWith('offline')
   })
 
   it('should report the device as missing when the revert fails', async () => {

--- a/tests/unit/melcloud-listener.test.ts
+++ b/tests/unit/melcloud-listener.test.ts
@@ -7,6 +7,14 @@ import { MELCloudListener } from '../../listeners/melcloud.mts'
 import { assertDefined, mock } from '../helpers.ts'
 import { type MockDevice, createMockDevice, names } from '../mocks.ts'
 
+// The capability listeners run their async bodies through
+// fireAndForget: invoking one returns before the work lands, so tests
+// flush a macrotask before asserting on the outcome.
+const settleListeners = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
 interface Harness {
   readonly app: MELCloudExtensionApp
   readonly attach: ReturnType<typeof vi.fn>
@@ -191,6 +199,7 @@ describe(MELCloudListener, () => {
     await harness.listener.listenToThermostatMode()
 
     await getInstance(harness, 'target_temperature').listener(26)
+    await settleListeners()
 
     expect(harness.settingsStore.thresholds).toStrictEqual({ 'ac-1': 26 })
     expect(
@@ -204,6 +213,7 @@ describe(MELCloudListener, () => {
     harness.pushToUI.mockClear()
 
     await getInstance(harness, 'target_temperature').listener(23)
+    await settleListeners()
 
     expect(harness.pushToUI).toHaveBeenCalledTimes(0)
   })
@@ -213,6 +223,7 @@ describe(MELCloudListener, () => {
     await harness.listener.listenToThermostatMode()
 
     await getInstance(harness, 'thermostat_mode').listener('cool')
+    await settleListeners()
 
     expect(
       harness.mockDevice.capabilityInstances.has('target_temperature'),
@@ -226,6 +237,7 @@ describe(MELCloudListener, () => {
     const firstInstance = getInstance(harness, 'target_temperature')
 
     await getInstance(harness, 'thermostat_mode').listener('cool')
+    await settleListeners()
 
     expect(getInstance(harness, 'target_temperature')).toBe(firstInstance)
     expect(harness.attach).toHaveBeenCalledTimes(1)
@@ -237,6 +249,7 @@ describe(MELCloudListener, () => {
     Object.assign(harness.settingsStore, { thresholds: {} })
 
     await getInstance(harness, 'thermostat_mode').listener('heat')
+    await settleListeners()
 
     expect(harness.mockDevice.setCapabilityValue).toHaveBeenCalledWith({
       capabilityId: 'target_temperature',
@@ -249,6 +262,7 @@ describe(MELCloudListener, () => {
     await harness.listener.listenToThermostatMode()
 
     await getInstance(harness, 'thermostat_mode').listener('heat')
+    await settleListeners()
 
     expect(
       getInstance(harness, 'target_temperature').destroy,
@@ -268,6 +282,7 @@ describe(MELCloudListener, () => {
     )
 
     await getInstance(harness, 'thermostat_mode').listener('heat')
+    await settleListeners()
 
     expect(harness.pushToUI).toHaveBeenCalledWith('error.notFound', {
       idOrName: 'Living room',

--- a/tests/unit/weather-source.test.ts
+++ b/tests/unit/weather-source.test.ts
@@ -90,6 +90,20 @@ describe(WeatherOutdoorSource, () => {
     expect(subscriber.setTargetTemperature).toHaveBeenCalledTimes(1)
   })
 
+  it('should log instead of crashing when a polled recalculation fails', async () => {
+    const harness = createHarness()
+    const subscriber = createSubscriber()
+    await harness.source.attach(subscriber)
+    harness.apiCall.mockReturnValue({ temperatureCelsius: 35.5 })
+    vi.mocked(subscriber.setTargetTemperature).mockRejectedValueOnce(
+      new Error('offline'),
+    )
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL)
+
+    expect(harness.error).toHaveBeenCalledWith('offline')
+  })
+
   it('should not broadcast an unchanged reading', async () => {
     const harness = createHarness()
     const subscriber = createSubscriber()


### PR DESCRIPTION
Extension slice of the cross-repo post-churn audit (multi-agent sweep, every finding re-verified against source). Sibling PRs: melcloud-api #1618, com.melcloud (same branch name).

## Real bugs
- **`Map.entries().map()` in the settings bundle** — iterator helpers are a 2025-era runtime API (Safari 18.4+), far above the documented es2020 webview floor; esbuild lowers syntax only, so this shipped unpolyfilled and crashes older phone webviews at `getSelectedSources`. Replaced by the spread idiom the file already uses two functions up. (`toSorted`/`toReversed` stay: es2023 array methods are the de-facto accepted floor — com.melcloud's charts widget ships them by documented lint decision.)
- **Unhandled rejections could kill the app** — the SDK invokes timer and capability-instance callbacks bare (`this.__listener(value, this)`, no catch), so a transient failure in the init debounce, the weather poll, or any of the three capability listeners became an unhandled rejection → process exit under Node's default policy. All five now route through `fireAndForget` with `this.error(...)`.
- **One watcher per sensor, even under concurrent fan-out** — `#getSource` awaited the source creation between the registry lookup and the `set`, so the devices of one building (the mainline grouping config) each created their own capability watcher, with only the last one registered. The map now memoizes the in-flight promise (set synchronously); failed creations uncache and retry.
- **Failed `start()` cached forever** — `#watching ??= this.start()` kept the rejection: after one transient failure every subsequent attach re-awaited the same rejection and the source never recovered. The guard now resets (and drops the failed attach's subscriber) on failure.
- **Retained history suppressed by one early live event** — a realtime 'log' landing between listener wiring (deliberately first) and the initial settings fetch left the pane showing only that row for the whole session. One-shot flag + rebuild from the persisted list (which already contains the early row — the app persists synchronously after emitting).

## CSS / webview polish (cold-open check requested before release)
- Palette on Homey Style Library tokens with today's hex as `var()` fallback — byte-identical when a token is absent, adaptive (dark theme) when present.
- The Configuration summary drops its hardcoded `1.375rem` (22 px — 2 px over the real legend scale) for `var(--homey-font-size-medium)`/`--homey-font-weight-bold` — the same fix com.melcloud shipped in #1444 — and the JS `matchLegendScale` computed-style copier goes with it.
- Buttons disable natively (`disabled` + `:disabled` styling) instead of the `pointer-events`-only class: blocks keyboard re-triggering mid-request, announced by screen readers.

## Dedup / hygiene
`getErrorMessage` + `fireAndForget` from `lib/` (verbatim copies removed, one documented disable instead of two, CLAUDE.md updated), `getElement` not-found diagnosis, `fetchListOrEmpty`, dead locale keys pruned (×13 both trees + 7 stale generated leftovers), ambient homey-api declaration trimmed to used surface, eslint ledger fully annotated.

Suite: 102 tests, 100 % branches, lint 0, typecheck/build/`homey:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)