### PR TITLE
docs: state the real webview runtime floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,9 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
   beacon POSTs the `userAgent` plus a `fetch` probe of the bundle to
   `/boot-error` (`app.error`) before degrading, distinguishing a fetch
   failure from a parse-or-runtime crash (pre-es2020 engines). Webview
-  code sticks to es2020-era runtime APIs (esbuild lowers syntax only). Settings pages and
+  runtime-API floor: es2023 array methods are accepted
+  (`toSorted`/`toReversed` ship today), but nothing newer — no iterator
+  helpers (`.entries().map()`, 2025-era): esbuild lowers syntax only. Settings pages and
   widgets do NOT style the same way: settings follow the Homey Style
   Library (`homey-form-*`/`homey-button-*`; in a `homey-form-group` the
   control is a SIBLING after its label — see


### PR DESCRIPTION
Doc-only follow-up to #1198: the doctrine said "es2020-era runtime APIs" while the settings bundle ships `toSorted`/`toReversed` (es2023) by lint mandate — the wording now matches reality: es2023 array methods accepted, iterator helpers (2025-era) and newer banned. Mirrors the same clarification landing in com.melcloud's CLAUDE.md (#1446).

🤖 Generated with [Claude Code](https://claude.com/claude-code)