### PR TITLE
feat: explicit per-device source seeding and refreshed log emojis (24.7.6)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -346,5 +346,20 @@
     "pl": "Bardziej niezawodna strona ustawień: kolory dostosowane do trybu ciemnego, natywnie wyłączane przyciski, historia, która już nie znika, i większa odporność na przejściowe błędy.",
     "ru": "Более надёжная страница настроек: цвета адаптируются к тёмной теме, кнопки отключаются нативно, история больше не исчезает, повышена устойчивость к временным сбоям.",
     "sv": "Mer tillförlitlig inställningssida: färger som anpassar sig till mörkt läge, nativt inaktiverade knappar, en historik som inte längre försvinner och bättre motståndskraft mot tillfälliga fel."
+  },
+  "24.7.6": {
+    "ar": "الأجهزة الجديدة لا تُضبط تلقائيًا بعد الآن: مبنى جديد يبدأ بوضع «عدم التفعيل»، وجهاز يُضاف إلى مبنى مُهيأ يرث إعداده — وتم تحديث الرموز التعبيرية للسجل.",
+    "da": "Nye enheder justeres ikke længere automatisk: en ny bygning starter som «Aktivér ikke», og en enhed, der føjes til en konfigureret bygning, arver dens indstilling — og loggens emojis er opdateret.",
+    "de": "Neue Geräte werden nicht mehr automatisch angepasst: Ein neues Gebäude startet mit «Nicht aktivieren», und ein Gerät in einem konfigurierten Gebäude erbt dessen Einstellung — und die Protokoll-Emojis wurden aufgefrischt.",
+    "en": "New devices are no longer auto-adjusted by default: a new building starts as 'Do not activate', and a device added to a configured building inherits its setting — and the log emojis got a refresh.",
+    "es": "Los dispositivos nuevos ya no se ajustan automáticamente: un edificio nuevo empieza en «No activar», y un dispositivo añadido a un edificio configurado hereda su ajuste — y los emojis del registro se han renovado.",
+    "fr": "Les nouveaux appareils ne sont plus ajustés d'office : un nouveau bâtiment démarre sur « Ne pas activer », et un appareil ajouté à un bâtiment configuré hérite de son réglage — et les emojis du journal ont été rafraîchis.",
+    "it": "I nuovi dispositivi non vengono più regolati automaticamente: un nuovo edificio parte su «Non attivare», e un dispositivo aggiunto a un edificio configurato ne eredita l'impostazione — e le emoji del registro sono state rinnovate.",
+    "ko": "새 장치는 더 이상 자동으로 조정되지 않습니다: 새 건물은 '활성화 안 함'으로 시작하고, 구성된 건물에 추가된 장치는 해당 설정을 상속합니다 — 로그 이모지도 새로워졌습니다.",
+    "nl": "Nieuwe apparaten worden niet meer automatisch aangepast: een nieuw gebouw start op 'Niet activeren', en een apparaat dat aan een geconfigureerd gebouw wordt toegevoegd erft de instelling — en de log-emoji's zijn opgefrist.",
+    "no": "Nye enheter justeres ikke lenger automatisk: en ny bygning starter som «Ikke aktiver», og en enhet lagt til i en konfigurert bygning arver innstillingen — og loggens emojier er oppdatert.",
+    "pl": "Nowe urządzenia nie są już domyślnie regulowane: nowy budynek zaczyna od «Nie aktywuj», a urządzenie dodane do skonfigurowanego budynku dziedziczy jego ustawienie — odświeżono też emoji dziennika.",
+    "ru": "Новые устройства больше не регулируются автоматически: новое здание начинает с «Не активировать», а устройство, добавленное в настроенное здание, наследует его настройку — и эмодзи журнала обновлены.",
+    "sv": "Nya enheter justeras inte längre automatiskt: en ny byggnad börjar som «Aktivera inte», och en enhet som läggs till i en konfigurerad byggnad ärver dess inställning — och loggens emojier har fräschats upp."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -194,5 +194,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.5"
+  "version": "24.7.6"
 }

--- a/app.json
+++ b/app.json
@@ -195,5 +195,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.5"
+  "version": "24.7.6"
 }

--- a/app.mts
+++ b/app.mts
@@ -16,6 +16,7 @@ import {
   type DeviceGroups,
   type ListenerParams,
   type Names,
+  type OutdoorSources,
   type TemperatureListenerData,
   type TimestampedLog,
   DISABLED_SOURCE,
@@ -251,6 +252,25 @@ export default class MELCloudExtensionApp extends App {
     }
   }
 
+  // Newcomers inherit their building's outdoor source when the
+  // siblings agree; a new building (or a mixed/ungrouped one) starts
+  // disabled so no device gets auto-adjusted without an opt-in.
+  #inheritedSource(deviceId: string, stored: OutdoorSources): string | null {
+    const group = this.#deviceGroups?.find(({ deviceIds }) =>
+      deviceIds.includes(deviceId),
+    )
+    const siblingSources = new Set(
+      (group?.deviceIds ?? [])
+        .filter((id) => id !== deviceId && Object.hasOwn(stored, id))
+        .map((id) => stored[id] ?? null),
+    )
+    if (siblingSources.size !== 1) {
+      return DISABLED_SOURCE
+    }
+    const [shared = DISABLED_SOURCE] = siblingSources
+    return shared
+  }
+
   // Debounces device list reload: rapid device.create/delete events
   // are coalesced into a single init after INIT_DELAY. The timer body
   // routes through fireAndForget: the SDK invokes it bare, so a
@@ -307,7 +327,7 @@ export default class MELCloudExtensionApp extends App {
       }
     }
     await this.refreshDeviceGroups()
-    this.#migrateLegacySource()
+    this.#reconcileSourceEntries()
   }
 
   // Older versions stored one global outdoor source: seed every known AC
@@ -334,5 +354,37 @@ export default class MELCloudExtensionApp extends App {
       'lastLogs',
       [newLog, ...lastLogs].slice(0, MAX_LOGS),
     )
+  }
+
+  // Storage upkeep after each device discovery: the one-time legacy
+  // migration, then the explicit per-device seeding.
+  #reconcileSourceEntries(): void {
+    this.#migrateLegacySource()
+    this.#seedOutdoorSources()
+  }
+
+  // Every known AC device gets an EXPLICIT outdoor-source entry, so a
+  // device appearing later is distinguishable from one whose entry was
+  // never written. The first seeding on an existing install stamps the
+  // legacy default (null = Homey weather) and changes nothing;
+  // afterwards newcomers go through #inheritedSource.
+  #seedOutdoorSources(): void {
+    const stored: OutdoorSources = {
+      ...this.homey.settings.get('outdoorSources'),
+    }
+    const newcomers = this.#melcloudDevices.filter(
+      ({ id }) => !Object.hasOwn(stored, id),
+    )
+    const isLegacySeed =
+      this.homey.settings.get('hasSeededOutdoorSources') !== true
+    for (const { id } of newcomers) {
+      stored[id] = isLegacySeed ? null : this.#inheritedSource(id, stored)
+    }
+    if (newcomers.length > 0) {
+      this.homey.settings.set('outdoorSources', stored)
+    }
+    if (isLegacySeed) {
+      this.homey.settings.set('hasSeededOutdoorSources', true)
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.5",
+  "version": "24.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.7.5",
+      "version": "24.7.6",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.5",
+  "version": "24.7.6",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -51,10 +51,10 @@ const errorCategory: LogCategory = {
 }
 
 const categories: Partial<Record<string, LogCategory>> = {
-  calculated: { colorClass: 'log-message-calculated', icon: '🔢' },
+  calculated: { colorClass: 'log-message-calculated', icon: '🎯' },
   cleaned: { icon: '🗑️' },
   cleanedAll: { icon: '🛑' },
-  created: { icon: '🔊' },
+  created: { icon: '📡' },
   error: errorCategory,
   listened: { colorClass: 'log-message-listened', icon: '👂' },
   reverted: { icon: '↩️' },

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -139,6 +139,106 @@ describe(MELCloudExtensionApp, () => {
     expect(app.deviceGroups).toStrictEqual(groups)
   })
 
+  it('should stamp the legacy weather default on the first seeding', async () => {
+    const { classicDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice])
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+    })
+    expect(mockHomey.settingsStore.hasSeededOutdoorSources).toBe(true)
+  })
+
+  it('should read absent settings as empty without any AC device', async () => {
+    const { sensorDevice } = createDevices()
+    const { mockHomey } = await createHarness([sensorDevice])
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({})
+  })
+
+  it('should default a newcomer in its own building to disabled', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice, homeDevice], {
+      settings: {
+        hasSeededOutdoorSources: true,
+        outdoorSources: { 'classic-1': 'sensor-1:measure_temperature.outdoor' },
+      },
+    })
+    mockHomey.apiAppGet.mockReturnValue([
+      { deviceIds: ['classic-1'], name: 'Domicile' },
+      { deviceIds: ['home-1'], name: 'Chalet' },
+    ])
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': 'sensor-1:measure_temperature.outdoor',
+      'home-1': 'none',
+    })
+  })
+
+  it('should default a newcomer to disabled when no grouping is available', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice, homeDevice], {
+      settings: {
+        hasSeededOutdoorSources: true,
+        outdoorSources: { 'classic-1': null },
+      },
+    })
+    mockHomey.apiAppGet.mockReturnValue('not-a-grouping')
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+      'home-1': 'none',
+    })
+  })
+
+  it('should inherit the building setting for a newcomer joining it', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice, homeDevice], {
+      settings: {
+        hasSeededOutdoorSources: true,
+        outdoorSources: { 'classic-1': 'sensor-1:measure_temperature.outdoor' },
+      },
+    })
+    mockHomey.apiAppGet.mockReturnValue([
+      { deviceIds: ['classic-1', 'home-1'], name: 'Domicile' },
+    ])
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': 'sensor-1:measure_temperature.outdoor',
+      'home-1': 'sensor-1:measure_temperature.outdoor',
+    })
+  })
+
+  it('should inherit the Homey-weather default from the building siblings', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice, homeDevice], {
+      settings: {
+        hasSeededOutdoorSources: true,
+        outdoorSources: { 'classic-1': null },
+      },
+    })
+    mockHomey.apiAppGet.mockReturnValue([
+      { deviceIds: ['classic-1', 'home-1'], name: 'Domicile' },
+    ])
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+      'home-1': null,
+    })
+  })
+
   it('should re-read the grouping on demand, following a rename', async () => {
     const { classicDevice } = createDevices()
     const { app, mockHomey } = await createHarness([classicDevice])
@@ -299,7 +399,11 @@ describe(MELCloudExtensionApp, () => {
     await advancePastInit()
 
     expect(mockHomey.settingsStore.isEnabled).toBe(false)
-    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({})
+    // The boot seeding stamps the legacy default (null = Homey weather)
+    // for devices that predate explicit entries.
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+    })
     expect(classicDevice.capabilityInstances.size).toBe(0)
   })
 

--- a/types.mts
+++ b/types.mts
@@ -22,6 +22,7 @@ export type DeviceGroups = readonly {
 
 export interface HomeySettings {
   readonly capabilityPath?: string | null
+  readonly hasSeededOutdoorSources?: boolean | null
   readonly isEnabled?: boolean | null
   readonly lastLogs?: TimestampedLog[] | null
   readonly notifiedVersion?: string | null


### PR DESCRIPTION
Olivier's three settings-page reports:

1. **New building defaulted to "Homey weather"** — absent entries read as the weather default at runtime, so a brand-new building started auto-adjusted without opt-in. Every known AC device now gets an **explicit** `outdoorSources` entry: the first seeding on an existing install stamps the legacy default (`null` = Homey weather; behavior preserved, one-time `hasSeededOutdoorSources` flag); afterwards a newcomer in its own (or ungrouped/mixed) building starts **disabled**.
2. **New device joining a configured building blanked its row** — the row derives from its devices' shared value, and the entry-less newcomer broke the consensus. A newcomer now **inherits the building's setting** when the siblings agree (including the explicit weather default), so the row stays as configured and the device follows it.
3. **Dated emojis** — `calculated` 🔢 → 🎯, `created` 🔊 → 📡 (the rest — 👂 🗑️ 🛑 ⚠️ ↩️ ☁️ — read fine and stay; easy to tweak further on the cold-open).

6 new seeding tests (legacy stamp, inherit, inherit-weather, own-building → disabled, no-grouping → disabled, empty install). Suite: 114 tests, 100 % everywhere, lint 0, publish-level validate. Installed on the Homey; ships as 24.7.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)