### PR TITLE
refactor: settle the Number.NaN convention (SonarCloud S7773 alignment)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -778,6 +778,10 @@ const config = defineConfig([
       'unicorn/prefer-dispose': 'error',
       // Requires Node.js 24 (`Error.isError`).
       'unicorn/prefer-error-is-error': 'off',
+      // Mutually exclusive twin of `prefer-number-properties`'
+      // `checkNaN`: the repos pick `Number.NaN` (SonarCloud S7773 is a
+      // required gate, and it pairs with the mandated `Number.isNaN`).
+      'unicorn/prefer-global-number-constants': 'off',
       'unicorn/prefer-import-meta-properties': 'error',
       // Requires Node.js 24 (`Iterator.concat`).
       'unicorn/prefer-iterator-concat': 'off',
@@ -787,6 +791,14 @@ const config = defineConfig([
         'error',
         {
           checkVaryingBase: true,
+        },
+      ],
+      // Stricter than the v72 default (see
+      // `prefer-global-number-constants` above).
+      'unicorn/prefer-number-properties': [
+        'error',
+        {
+          checkNaN: true,
         },
       ],
       // Requires Node.js 24 (`RegExp.escape`).


### PR DESCRIPTION
Same verdict as com.melcloud #1450, pinned before the project's CI-based Sonar analysis arms: `prefer-number-properties` gains `checkNaN: true`, its mutually exclusive twin `prefer-global-number-constants` goes to the config ledger with the rationale. No existing usages — config only. Quality-only, rides the next release. Suite: lint 0, tsc 0, 100 % coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)