### PR TITLE
chore(release): 24.7.7

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -361,5 +361,20 @@
     "pl": "Nowe urządzenia nie są już domyślnie regulowane: nowy budynek zaczyna od «Nie aktywuj», a urządzenie dodane do skonfigurowanego budynku dziedziczy jego ustawienie — odświeżono też emoji dziennika.",
     "ru": "Новые устройства больше не регулируются автоматически: новое здание начинает с «Не активировать», а устройство, добавленное в настроенное здание, наследует его настройку — и эмодзи журнала обновлены.",
     "sv": "Nya enheter justeras inte längre automatiskt: en ny byggnad börjar som «Aktivera inte», och en enhet som läggs till i en konfigurerad byggnad ärver dess inställning — och loggens emojier har fräschats upp."
+  },
+  "24.7.7": {
+    "ar": "تحسين سهم التوسيع/الطي في الإعدادات.",
+    "da": "Forfinet fold ud/sammen-pil i indstillingerne.",
+    "de": "Verfeinerter Ein-/Ausklapp-Pfeil in den Einstellungen.",
+    "en": "Refined the settings collapse/expand chevron.",
+    "es": "Chevron de expandir/contraer de los ajustes refinado.",
+    "fr": "Chevron d'ouverture/fermeture des réglages affiné.",
+    "it": "Chevron di apertura/chiusura delle impostazioni rifinito.",
+    "ko": "설정의 펼치기/접기 화살표를 개선했습니다.",
+    "nl": "Verfijnde in-/uitklap-pijl in de instellingen.",
+    "no": "Forfinet vis/skjul-pil i innstillingene.",
+    "pl": "Dopracowana strzałka zwijania/rozwijania w ustawieniach.",
+    "ru": "Улучшена стрелка разворачивания/сворачивания в настройках.",
+    "sv": "Förfinad expandera/komprimera-pil i inställningarna."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -194,5 +194,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.6"
+  "version": "24.7.7"
 }

--- a/app.json
+++ b/app.json
@@ -195,5 +195,5 @@
       "värmepump"
     ]
   },
-  "version": "24.7.6"
+  "version": "24.7.7"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.6",
+  "version": "24.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "24.7.6",
+      "version": "24.7.7",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "24.7.6",
+  "version": "24.7.7",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
Release **24.7.7** — settings collapse/expand chevron (#1206).

Bump + `.homeychangelog.json` (13 locales) + `homey validate --level publish` (green). Tag + GitHub release fires `publish.yml` to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)