### PR TITLE
chore: finish the jsdoc @throws switch

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -47,7 +47,7 @@ const api = {
    * @param options - Homey API context.
    * @param options.homey - Homey instance carrying the app.
    * @returns The groups, sorted by name, devices sorted within.
-   * @rejects {NotFoundError} when no MELCloud AC device is paired yet.
+   * @throws {@link NotFoundError} when no MELCloud AC device is paired yet.
    */
   async getAdjustableGroups({
     homey,
@@ -83,7 +83,7 @@ const api = {
    * @param options - Homey API context.
    * @param options.homey - Homey instance carrying the app.
    * @returns The selectable sensors.
-   * @throws NotFoundError when no MELCloud AC device is paired yet.
+   * @throws {@link NotFoundError} when no MELCloud AC device is paired yet.
    */
   getTemperatureSensors({ homey }: { homey: Homey }): TemperatureSensor[] {
     const { melcloudDevices, temperatureSensors } = homey.app

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -866,6 +866,7 @@ const config = defineConfig([
         'jsdoc/require-yields-description': 'error',
         'jsdoc/sort-tags': 'error',
       },
+      settings: { tagNamePreference: { rejects: 'throws' } },
     }),
     files: ['{api,app,files,types}.mts', 'lib/**/*.mts', 'listeners/**/*.mts'],
   },


### PR DESCRIPTION
Follow-up: the `@rejects`→`@throws` re-evaluation was dropped from #1208 by an amend-script bug (missing `cd`), so main still had the non-standard `@rejects` tag + a bare `@throws`. This lands the intended state, matching the other four repos:
- `settings.jsdoc.tagNamePreference = { rejects: 'throws' }` (merged **into** the `jsdoc()` call so the preset's `structuredTags` survive)
- both `getAdjustableGroups` and `getTemperatureSensors` documented with the standard `@throws {@link NotFoundError}`

Internal only (jsdoc comments/config). lint/format/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)