### PR TITLE
refactor: adopt the shared dirty-gate primitive in settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,14 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
 
 - `.homeycompose/` is the SOURCE for `app.json` and `locales/*.json`;
   commit the CLI-generated outputs verbatim (no trailing newline).
+- Dirty-gating: `settings/dirty-gate.mts` is the ONE primitive behind the
+  Update/Refresh pair — never re-derive its invariant at a call site. Its
+  `serialize` must stay a PURE form snapshot, never a request-body
+  builder, and disabled greying styles `button:disabled` generically,
+  never a per-class list. `tests/dirty-gate.test.ts` locks the behavior;
+  the module is a byte-identical copy of com.melcloud's
+  `public/dirty-gate.mts` (com.heatzy carries the third copy) — edit all
+  three together.
 - Home ATA devices (`home-melcloud`) do NOT expose
   `measure_temperature.outdoor`; only Classic ATA devices do. The
   default outdoor-source selection and the sensor list must never

--- a/settings/dirty-gate.mts
+++ b/settings/dirty-gate.mts
@@ -1,0 +1,88 @@
+// The webviews' shared dirty-gating primitive: one gate owns one Apply
+// button — greyed while the form matches its saved baseline OR a request
+// is in flight — and its sibling Refresh buttons, greyed by busy alone so
+// they stay the escape hatch on a pristine form. The factory owns the
+// whole invariant; a call site only supplies `serialize`. Byte-identical
+// copies of this module live in the sibling Homey apps — edit them
+// together.
+
+export interface DirtyGate {
+  readonly markSaved: () => void
+  readonly recompute: () => void
+  readonly runBusy: (action: () => Promise<void>) => Promise<void>
+  readonly setBusy: (isBusy: boolean) => void
+  readonly wire: (targets: readonly EventTarget[]) => void
+}
+
+export interface DirtyGateOptions {
+  readonly applyElement: HTMLButtonElement
+  readonly refreshElements?: readonly HTMLButtonElement[]
+  readonly serialize: () => string
+}
+
+// `input` covers live typing in number/date fields; `change` covers the
+// selects and the final commit (and, since `serialize` reads the whole
+// form, any field a cascade handler mutated).
+const wireRecompute = (
+  targets: readonly EventTarget[],
+  recompute: () => void,
+): void => {
+  for (const target of targets) {
+    for (const eventName of ['change', 'input']) {
+      target.addEventListener(eventName, recompute)
+    }
+  }
+}
+
+// `serialize` must be a PURE snapshot of the form's current values — never
+// a request-body builder: those filter defaults and null deltas out, which
+// desyncs the pristine check. The gate snapshots it at creation, so Apply
+// starts greyed even when no data ever loads; call `markSaved` after every
+// (re)populate and successful save, `wire` on the controls the snapshot
+// reads, and route every request through `runBusy`.
+export const createDirtyGate = ({
+  applyElement,
+  refreshElements = [],
+  serialize,
+}: DirtyGateOptions): DirtyGate => {
+  let busyGeneration = 0
+  let isBusy = false
+  let saved = serialize()
+  // Native `disabled` (not a CSS class): it blocks keyboard activation
+  // during in-flight actions and is announced by screen readers.
+  const recompute = (): void => {
+    applyElement.disabled = isBusy || serialize() === saved
+  }
+  const markSaved = (): void => {
+    saved = serialize()
+    recompute()
+  }
+  // Refresh is gated by busy ALONE (never dirty); Apply folds the busy
+  // flag into its dirty check so a mid-request edit cannot re-enable it.
+  const setBusy = (isBusyNow: boolean): void => {
+    isBusy = isBusyNow
+    for (const element of refreshElements) {
+      element.disabled = isBusyNow
+    }
+    recompute()
+  }
+  // Generation-tokened: only the action holding the latest claim may
+  // release the busy state, so an overlapping action can never free the
+  // buttons a live request still owns.
+  const runBusy = async (action: () => Promise<void>): Promise<void> => {
+    const generation = ++busyGeneration
+    setBusy(true)
+    try {
+      await action()
+    } finally {
+      if (generation === busyGeneration) {
+        setBusy(false)
+      }
+    }
+  }
+  const wire = (targets: readonly EventTarget[]): void => {
+    wireRecompute(targets, recompute)
+  }
+  recompute()
+  return { markSaved, recompute, runBusy, setBusy, wire }
+}

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -13,6 +13,7 @@ import {
   type TimestampedLog,
   DISABLED_SOURCE,
 } from '../types.mts'
+import { createDirtyGate } from './dirty-gate.mts'
 
 // Give slow transports a real chance while keeping the loading overlay
 // finite: past this point the page surfaces the failure instead.
@@ -169,59 +170,19 @@ const closeOpenCombobox = (): void => {
 
 // "Update" only means something once the form diverges from the last
 // saved state — the snapshot greys it out otherwise.
-const savedState: { value: string } = { value: '' }
-
 const serializeState = (): string =>
   JSON.stringify([
     enabledElement.value,
     [...sourceSelections].toSorted(([id1], [id2]) => id1.localeCompare(id2)),
   ])
 
-// Requests in flight lock BOTH buttons: `updateDirty` folds the busy
-// flag in so a combobox pick mid-request cannot re-enable Update.
-const busyState: { value: boolean } = { value: false }
-
-const updateDirty = (): void => {
-  // Native `disabled` (com.melcloud form): it also blocks keyboard
-  // activation mid-request and is announced by screen readers.
-  applyElement.disabled =
-    busyState.value || serializeState() === savedState.value
-}
-
-const resetSavedState = (): void => {
-  savedState.value = serializeState()
-  updateDirty()
-}
-
 // Busy buttons only grey out (com.melcloud behavior): the style
 // library's `is-loading` spinner shifts the label sideways.
-const setButtonsBusy = (areBusy: boolean): void => {
-  busyState.value = areBusy
-  refreshElement.disabled = areBusy
-  updateDirty()
-}
-
-// Generation-tokened: a hung action force-released by the init timeout
-// must not clear (or re-set) the busy state a later, live action owns.
-const busyGeneration = { value: 0 }
-
-const releaseBusyButtons = (): void => {
-  busyGeneration.value += 1
-  setButtonsBusy(false)
-}
-
-const withBusyButtons = async (action: () => Promise<void>): Promise<void> => {
-  busyGeneration.value += 1
-  const generation = busyGeneration.value
-  setButtonsBusy(true)
-  try {
-    await action()
-  } finally {
-    if (generation === busyGeneration.value) {
-      setButtonsBusy(false)
-    }
-  }
-}
+const dirtyGate = createDirtyGate({
+  applyElement,
+  refreshElements: [refreshElement],
+  serialize: serializeState,
+})
 
 // The document language is the display locale: `fetchLanguage` overwrites
 // the html attribute's default with the Homey-configured language.
@@ -439,7 +400,7 @@ const enableAdjustment = (): void => {
   if (enabledElement.value === 'false') {
     enabledElement.value = 'true'
   }
-  updateDirty()
+  dirtyGate.recompute()
 }
 
 const registerSourceOption = (name: string, value: string): void => {
@@ -748,7 +709,7 @@ const getSelectedSources = (): OutdoorSources =>
   )
 
 const autoAdjustCooling = async (homey: Homey): Promise<void> =>
-  withBusyButtons(async () => {
+  dirtyGate.runBusy(async () => {
     try {
       await homeyCallback<undefined>((callback) => {
         homey.api(
@@ -761,7 +722,7 @@ const autoAdjustCooling = async (homey: Homey): Promise<void> =>
           callback,
         )
       })
-      resetSavedState()
+      dirtyGate.markSaved()
     } catch (error) {
       await homey.alert(getErrorMessage(error))
     }
@@ -770,10 +731,10 @@ const autoAdjustCooling = async (homey: Homey): Promise<void> =>
 // Refresh restores every value to the last saved state (the stored
 // enable flag and per-device sources)
 const refreshAll = async (homey: Homey): Promise<void> =>
-  withBusyButtons(async () => {
+  dirtyGate.runBusy(async () => {
     await populateSources(homey)
     await fetchHomeySettings(homey)
-    resetSavedState()
+    dirtyGate.markSaved()
   })
 
 const addEventListeners = (homey: Homey): void => {
@@ -793,7 +754,7 @@ const addEventListeners = (homey: Homey): void => {
   applyElement.addEventListener('click', () => {
     fireAndForget(autoAdjustCooling(homey))
   })
-  enabledElement.addEventListener('change', updateDirty)
+  dirtyGate.wire([enabledElement])
   installElement.addEventListener('click', () => {
     fireAndForget(homey.openURL('https://homey.app/a/com.mecloud'))
   })
@@ -809,13 +770,14 @@ const run = async (homey: Homey): Promise<void> => {
   await refreshAll(homey)
 }
 
-// A timed-out load may still be hung inside `withBusyButtons` — release
-// the controls (and orphan that run's busy claim) so the retry is
-// actually clickable. Fire-and-forget on the alert keeps `start()`
-// non-throwing: a rejected alert must not trip the HTML loader's catch
-// (double `ready()`, second generic alert).
+// A timed-out load may still be hung inside `runBusy` — release the
+// controls so the retry is actually clickable; the gate's generation
+// guard keeps that hung run's finally from touching a later, live
+// claim. Fire-and-forget on the alert keeps `start()` non-throwing: a
+// rejected alert must not trip the HTML loader's catch (double
+// `ready()`, second generic alert).
 const reportInitFailure = (homey: Homey, error: unknown): void => {
-  releaseBusyButtons()
+  dirtyGate.setBusy(false)
   fireAndForget(homey.alert(getErrorMessage(error)))
 }
 

--- a/tests/dirty-gate.test.ts
+++ b/tests/dirty-gate.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDirtyGate } from '../settings/dirty-gate.mts'
+
+// The gate is headless: buttons only need a `disabled` slot, and wired
+// targets only need to dispatch events, so plain doubles are enough.
+const setup = (): {
+  applyElement: HTMLButtonElement
+  form: { value: string }
+  gate: ReturnType<typeof createDirtyGate>
+  refreshElement: HTMLButtonElement
+} => {
+  const applyElement = { disabled: false } as unknown as HTMLButtonElement
+  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const form = { value: 'pristine' }
+  const gate = createDirtyGate({
+    applyElement,
+    refreshElements: [refreshElement],
+    serialize: () => form.value,
+  })
+  return { applyElement, form, gate, refreshElement }
+}
+
+describe('dirty gate', () => {
+  it('should start pristine with Apply greyed and Refresh live', () => {
+    const { applyElement, refreshElement } = setup()
+
+    expect(applyElement.disabled).toBe(true)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should enable Apply when the form diverges and grey it once saved', () => {
+    const { applyElement, form, gate } = setup()
+
+    form.value = 'edited'
+    gate.recompute()
+
+    expect(applyElement.disabled).toBe(false)
+
+    gate.markSaved()
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should recompute on change and input events from wired targets', () => {
+    const { applyElement, form, gate } = setup()
+    const target = new EventTarget()
+    gate.wire([target])
+
+    form.value = 'edited'
+    target.dispatchEvent(new Event('change'))
+
+    expect(applyElement.disabled).toBe(false)
+
+    form.value = 'pristine'
+    target.dispatchEvent(new Event('input'))
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should grey both buttons while busy and restore them after', () => {
+    const { applyElement, form, gate, refreshElement } = setup()
+
+    form.value = 'edited'
+    gate.setBusy(true)
+
+    expect(applyElement.disabled).toBe(true)
+    expect(refreshElement.disabled).toBe(true)
+
+    gate.setBusy(false)
+
+    expect(applyElement.disabled).toBe(false)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should release the buttons when the action rejects and keep the edit dirty', async () => {
+    const { applyElement, form, gate, refreshElement } = setup()
+
+    form.value = 'edited'
+
+    await expect(
+      gate.runBusy(async () => {
+        await Promise.reject(new Error('boom'))
+      }),
+    ).rejects.toThrow('boom')
+
+    expect(applyElement.disabled).toBe(false)
+    expect(refreshElement.disabled).toBe(false)
+  })
+
+  it('should let only the latest claim release the busy state', async () => {
+    const { gate, refreshElement } = setup()
+    const firstClaim = Promise.withResolvers<null>()
+    const secondClaim = Promise.withResolvers<null>()
+    const first = gate.runBusy(async () => {
+      await firstClaim.promise
+    })
+    const second = gate.runBusy(async () => {
+      await secondClaim.promise
+    })
+
+    firstClaim.resolve(null)
+    await first
+
+    expect(refreshElement.disabled).toBe(true)
+
+    secondClaim.resolve(null)
+    await second
+
+    expect(refreshElement.disabled).toBe(false)
+  })
+})


### PR DESCRIPTION
Aligns the extension — the origin of the dirty-gating pattern — on the **shared headless primitive**, so all three apps now run byte-identical copies of one module.

## What
- **`settings/dirty-gate.mts`** — byte-identical copy of com.melcloud's `public/dirty-gate.mts` (com.heatzy carries the third copy): `createDirtyGate({applyElement, refreshElements, serialize})` owns Update-pristine/busy gating, Refresh busy-only gating, saved-baseline snapshots, generation-tokened busy claims, and control wiring.
- **`settings/index.mts`** — drops the page-local pieces (`savedState`/`busyState`/`busyGeneration` boxes, `updateDirty`, `resetSavedState`, `setButtonsBusy`, `releaseBusyButtons`, `withBusyButtons`). `serializeState` stays the only page-specific piece (a pure form snapshot). The init timeout's force-release maps to `gate.setBusy(false)` — the gate's generation guard already keeps a hung run's `finally` from touching a later, live claim, which is exactly what `releaseBusyButtons`'s manual bump enforced.
- **`tests/dirty-gate.test.ts`** — 6 behavior-locking tests, identical to the twins in the sibling repos.
- **CLAUDE.md** — doctrine: module ownership, serialize purity, generic `button:disabled` (already the form here), edit-all-three rule.

No behavior change intended. Full suite green (120 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
