### PR TITLE
style: drop the experimentalTernaries flag

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -97,9 +97,8 @@ const api = {
         const capabilities = Object.values(capabilitiesObj ?? {}).filter(
           ({ id }) => id.startsWith(MEASURE_TEMPERATURE),
         )
-        const selectable =
-          melcloudDevices.includes(device) ?
-            capabilities.filter(({ id }) => id === OUTDOOR_TEMPERATURE)
+        const selectable = melcloudDevices.includes(device)
+          ? capabilities.filter(({ id }) => id === OUTDOOR_TEMPERATURE)
           : capabilities
         return selectable.map(({ id, title }): TemperatureSensor => ({
           capabilityName: `${deviceName} - ${title}`,

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from 'prettier'
 
 const config: Config = {
-  experimentalTernaries: true,
   plugins: ['prettier-plugin-packagejson'],
   semi: false,
   singleQuote: true,

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -72,9 +72,9 @@ const surfaceError = (error: unknown): void => {
     return
   }
   setTimeout(() => {
-    throw error instanceof Error ? error : (
-        new Error('Unhandled settings error', { cause: error })
-      )
+    throw error instanceof Error
+      ? error
+      : new Error('Unhandled settings error', { cause: error })
   }, 0)
 }
 
@@ -512,9 +512,9 @@ const renderOptions = (
 ): void => {
   const needle = params.filter.trim().toLowerCase()
   const matches =
-    needle === '' ? sourceOptions : (
-      sourceOptions.filter(({ name }) => name.toLowerCase().includes(needle))
-    )
+    needle === ''
+      ? sourceOptions
+      : sourceOptions.filter(({ name }) => name.toLowerCase().includes(needle))
   list.replaceChildren(
     ...matches.map((option) => createOptionItem(option, params)),
   )

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -92,11 +92,10 @@ const createHarness = async (
     settings = {},
     version = '0.0.0',
   }: {
-    readonly settings?: Parameters<typeof createMockHomey>[0] extends (
+    readonly settings?: Parameters<typeof createMockHomey>[0] extends
       { settings?: infer TSettings } | undefined
-    ) ?
-      TSettings
-    : never
+      ? TSettings
+      : never
     readonly version?: string
   } = {},
 ): Promise<Harness> => {


### PR DESCRIPTION
Removes `experimentalTernaries: true` from `prettier.config.ts` and reformats (4 files). Family-wide change — rationale in OlivierZal/com.melcloud#1471. Formatting-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)