### PR TITLE
feat: polish the log timeline (day separators, clock time for past days)

### DIFF
--- a/settings/index.mts
+++ b/settings/index.mts
@@ -200,20 +200,34 @@ const absoluteTime = (time: number): string =>
 
 const MINUTE_MS = 60_000
 const HOUR_MS = 3_600_000
-const DAY_MS = 86_400_000
 
-const relativeTime = (time: number): string => {
-  const elapsed = time - Temporal.Now.instant().epochMilliseconds
+const dayOf = (time: number): string =>
+  Temporal.Instant.fromEpochMilliseconds(time)
+    .toZonedDateTimeISO(Temporal.Now.timeZoneId())
+    .toPlainDate()
+    .toString()
+
+const clockTime = (time: number): string =>
+  Temporal.Instant.fromEpochMilliseconds(time).toLocaleString(
+    document.documentElement.lang,
+    { hour: 'numeric', minute: 'numeric' },
+  )
+
+// Today's entries read as recency ("2 hours ago"); older entries read as
+// clock time — their day separator already carries the date, and a
+// relative label is rendered once, so it only goes staler with age.
+const logTime = (time: number): string => {
+  const now = Temporal.Now.instant().epochMilliseconds
+  if (dayOf(time) !== dayOf(now)) {
+    return clockTime(time)
+  }
+  const elapsed = time - now
   const format = new Intl.RelativeTimeFormat(document.documentElement.lang, {
     numeric: 'auto',
   })
-  if (Math.abs(elapsed) < HOUR_MS) {
-    return format.format(Math.round(elapsed / MINUTE_MS), 'minute')
-  }
-  if (Math.abs(elapsed) < DAY_MS) {
-    return format.format(Math.round(elapsed / HOUR_MS), 'hour')
-  }
-  return format.format(Math.round(elapsed / DAY_MS), 'day')
+  return Math.abs(elapsed) < HOUR_MS
+    ? format.format(Math.round(elapsed / MINUTE_MS), 'minute')
+    : format.format(Math.round(elapsed / HOUR_MS), 'hour')
 }
 
 const createTimeElement = (time: number, icon: string): HTMLDivElement => {
@@ -221,7 +235,7 @@ const createTimeElement = (time: number, icon: string): HTMLDivElement => {
   timeElement.classList.add('log-time')
   timeElement.title = absoluteTime(time)
   timeElement.append(
-    document.createTextNode(relativeTime(time)),
+    document.createTextNode(logTime(time)),
     document.createElement('br'),
     document.createTextNode(icon),
   )
@@ -242,12 +256,6 @@ const createMessageElement = (
 
 // One separator above each day's logs (newest day on top)
 const topDay: { value: string | null } = { value: null }
-
-const dayOf = (time: number): string =>
-  Temporal.Instant.fromEpochMilliseconds(time)
-    .toZonedDateTimeISO(Temporal.Now.timeZoneId())
-    .toPlainDate()
-    .toString()
 
 const createDayElement = (time: number): HTMLDivElement => {
   const dayElement = document.createElement('div')

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -119,11 +119,20 @@ button:disabled {
   translate: 0 -65%;
 }
 
+/* Day separators are break tokens, not entries: centered (the timeline
+   convention) and sentence-cased — CLDR weekday names are running-text
+   forms (fr: “samedi”), and `::first-letter` casing is per-script, so
+   caseless scripts are unaffected. */
 .log-day {
   color: var(--homey-color-text-light, #888);
   font-weight: 600;
   grid-column: 1 / -1;
   padding-block: 0.5em;
+  text-align: center;
+}
+
+.log-day::first-letter {
+  text-transform: uppercase;
 }
 
 /* The collapsible configuration panel: the summary doubles as the


### PR DESCRIPTION
Two UX corrections on the settings log timeline, following the modern conventions for day-separated feeds:

- **Day separators** («samedi 25 juillet») are now **centered** and **sentence-cased** («Samedi 25 juillet»). Centering marks them as break tokens (the messaging-timeline convention); the capital comes from CSS `::first-letter` — presentational, per-script, so caseless scripts are unaffected, and the CLDR running-text form stays untouched in the DOM.
- **Past days' entries** now show **clock time** («23:10») instead of «il y a N jours»: their day separator already carries the date, and a relative label is rendered once, so it only went staler with age. **Today's** entries keep the recency form (minutes, then hours). The full absolute timestamp stays on the tooltip.

Full suite green (120 tests). Installed on-device for cold-open verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)