### PR TITLE
docs: prune comments to the doctrine (intent and constraint only)

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -113,10 +113,9 @@ export default class MELCloudExtensionApp extends App {
     await this.#destroyListeners()
   }
 
-  // Starts or restarts automatic cooling adjustment. Destroys existing
-  // listeners first, then creates one listener per AC device from the
-  // provided or stored per-device outdoor sources. A device whose source
-  // fails to validate is reported and skipped; the others keep running.
+  // Starts or restarts automatic cooling adjustment. A device whose
+  // source fails to validate is reported and skipped; the others keep
+  // running.
   public async autoAdjustCooling(
     temperatureListenerData?: TemperatureListenerData,
   ): Promise<void> {
@@ -309,7 +308,7 @@ export default class MELCloudExtensionApp extends App {
   }
 
   // Categorizes all Homey devices into MELCloud AC units and temperature
-  // sensors. Devices without an explicit source use the Homey weather.
+  // sensors.
   async #loadDevices(): Promise<void> {
     this.#melcloudDevices.length = 0
     this.#temperatureSensors.length = 0
@@ -356,8 +355,6 @@ export default class MELCloudExtensionApp extends App {
     )
   }
 
-  // Storage upkeep after each device discovery: the one-time legacy
-  // migration, then the explicit per-device seeding.
   #reconcileSourceEntries(): void {
     this.#migrateLegacySource()
     this.#seedOutdoorSources()

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -186,7 +186,6 @@ const config = defineConfig([
           types: ['boolean'],
         },
         // ── Parameters ───────────────────────────────────────
-        // Unused parameters must wear the underscore.
         {
           format: ['camelCase'],
           leadingUnderscore: 'require',

--- a/listeners/melcloud.mts
+++ b/listeners/melcloud.mts
@@ -171,12 +171,8 @@ export class MELCloudListener {
     return this.#app.homey.settings.get('thresholds') ?? {}
   }
 
-  // Starts monitoring target temperature for this AC device:
-  // 1. Attaches to the outdoor source first (dependency)
-  // 2. Captures current target temperature as the initial threshold
-  // 3. Listens for manual changes: if the user sets a different value
-  //    than what was auto-calculated, it becomes the new threshold
-  // 4. Triggers an initial recalculation via #setThreshold
+  // The current target temperature seeds the user threshold; a manual
+  // change away from the auto-calculated value becomes the new threshold.
   async #listenToTargetTemperature(): Promise<void> {
     if (this.#targetTemperatureListener !== null) {
       return

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -43,9 +43,7 @@ await Promise.all([
 ])
 
 // Courtesy cleanup: builds predating the `.homeybuild` emission left
-// bundles in the source tree. The CLI would copy them into the package,
-// where this build immediately overwrites them — harmless, but they
-// linger confusingly in the working tree.
+// bundles in the source tree; they only linger confusingly there.
 await Promise.all(
   ['settings/index.js', 'settings/index.mjs'].map(async (file) =>
     rm(file, { force: true }),

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -138,8 +138,7 @@ button:disabled {
 /* The collapsible configuration panel: the summary doubles as the
    fieldset legend, but Homey's style library sizes legends through the
    `legend` element, not the class — restate the legend's own tokens
-   (20px medium, bold — the old hardcoded 1.375rem sat 2px over it),
-   plus the click affordance a legend lacks. */
+   (20px medium, bold), plus the click affordance a legend lacks. */
 summary.homey-form-legend {
   align-items: center;
   cursor: pointer;


### PR DESCRIPTION
Family-wide comment pass (adversarially reviewed proposal by proposal): drops reviewer narration, debate relics, version/library provenance and restatements of adjacent code; trims verbose blocks to their load-bearing constraint; fixes (partially) obsolete comments. On-device evidence, config triage-ledger reasons and lint-required JSDoc untouched. **No code changes** — 5 files changed, 8 insertions(+), 19 deletions(-). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)