### PR TITLE
refactor: harmonize the app-API surface (shared transport, kebab-case path)

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -2,6 +2,10 @@
   "api": {
     "autoAdjustCooling": {
       "method": "PUT",
+      "path": "/cooling/auto-adjustment"
+    },
+    "autoAdjustCoolingLegacy": {
+      "method": "PUT",
       "path": "/melcloud/cooling/auto_adjustment"
     },
     "getAdjustableGroups": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,17 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
 
 - `.homeycompose/` is the SOURCE for `app.json` and `locales/*.json`;
   commit the CLI-generated outputs verbatim (no trailing newline).
+- App-API surface conventions (aligned on com.melcloud): paths are
+  kebab-case REST, `get*` for GET; `fetch*` in the webview is reserved
+  for transport calls (`load*` reads the settings store). The current
+  auto-adjustment path is `/cooling/auto-adjustment`;
+  `/melcloud/cooling/auto_adjustment` (`autoAdjustCoolingLegacy`) is
+  FROZEN — cached pre-rename bundles still PUT it, never remove it.
+  The com.melcloud grouping is probed `/devices/groups` first, then the
+  frozen `/device_groups` (an older com.melcloud during version skew).
+  `settings/callback-api.mts` is the settings page's transport
+  (error-first-callback SDK), a byte-identical copy of com.melcloud's
+  (com.heatzy carries the third) — edit all three together.
 - Dirty-gating: `settings/dirty-gate.mts` is the ONE primitive behind the
   Update/Refresh pair — never re-derive its invariant at a call site. Its
   `serialize` must stay a PURE form snapshot, never a request-body

--- a/api.mts
+++ b/api.mts
@@ -36,6 +36,20 @@ const api = {
     await app.autoAdjustCooling(body)
   },
   /**
+   * Serves the frozen legacy path `/melcloud/cooling/auto_adjustment`:
+   * phone webviews cache the settings bundle across app versions, so a
+   * pre-rename bundle still PUTs here — never remove it.
+   * @param context - Homey API context.
+   * @param context.body - Selected outdoor source and enablement flag.
+   * @param context.homey - Homey instance carrying the app.
+   */
+  async autoAdjustCoolingLegacy(context: {
+    body: TemperatureListenerData
+    homey: Homey
+  }): Promise<void> {
+    await api.autoAdjustCooling(context)
+  },
+  /**
    * Lists the settings rows: one named group per MELCloud building
    * (com.melcloud's inter-app grouping), unmatched devices trailing in
    * an unnamed group, or a single unnamed flat group when no grouping

--- a/app.json
+++ b/app.json
@@ -3,6 +3,10 @@
   "api": {
     "autoAdjustCooling": {
       "method": "PUT",
+      "path": "/cooling/auto-adjustment"
+    },
+    "autoAdjustCoolingLegacy": {
+      "method": "PUT",
       "path": "/melcloud/cooling/auto_adjustment"
     },
     "getAdjustableGroups": {

--- a/app.mts
+++ b/app.mts
@@ -214,10 +214,20 @@ export default class MELCloudExtensionApp extends App {
 
   async #fetchDeviceGroups(): Promise<DeviceGroups | null> {
     try {
-      const payload: unknown = await this.#melcloudApp.get('/device_groups')
-      return toDeviceGroups(payload)
+      return toDeviceGroups(await this.#fetchDeviceGroupsPayload())
     } catch {
       return null
+    }
+  }
+
+  // com.melcloud serves the grouping on `/devices/groups` and keeps the
+  // frozen legacy `/device_groups` alias; probing new-then-legacy rides
+  // out version skew between the two independently-updated apps.
+  async #fetchDeviceGroupsPayload(): Promise<unknown> {
+    try {
+      return await this.#melcloudApp.get('/devices/groups')
+    } catch {
+      return this.#melcloudApp.get('/device_groups')
     }
   }
 

--- a/settings/callback-api.mts
+++ b/settings/callback-api.mts
@@ -1,0 +1,58 @@
+import type Homey from 'homey/lib/HomeySettings'
+
+// The settings SDK's `homey.api`/`homey.confirm` are error-first
+// callbacks (unlike the widget SDK's promise-returning `homey.api`), so
+// the settings pages share one promisification primitive and per-verb
+// wrappers over it. Byte-identical copies of this module live in the
+// sibling Homey apps — edit them together.
+export const homeyCallback = async <T,>(
+  call: (callback: (error: Error | null, result: T) => void) => void,
+): Promise<T> =>
+  new Promise((resolve, reject) => {
+    call((error, result) => {
+      if (error !== null) {
+        reject(error)
+        return
+      }
+      resolve(result)
+    })
+  })
+
+export const homeyApiDelete = async (
+  homey: Homey,
+  path: string,
+): Promise<void> =>
+  homeyCallback((callback) => {
+    homey.api('DELETE', path, callback)
+  })
+
+export const homeyApiGet = async <T,>(homey: Homey, path: string): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('GET', path, callback)
+  })
+
+export const homeyApiPost = async <T,>(
+  homey: Homey,
+  path: string,
+  body: unknown,
+): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('POST', path, body, callback)
+  })
+
+export const homeyApiPut = async <T,>(
+  homey: Homey,
+  path: string,
+  body: unknown,
+): Promise<T> =>
+  homeyCallback((callback) => {
+    homey.api('PUT', path, body, callback)
+  })
+
+export const homeyConfirm = async (
+  homey: Homey,
+  message: string,
+): Promise<boolean> =>
+  homeyCallback((callback) => {
+    homey.confirm(message, null, callback)
+  })

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -13,6 +13,7 @@ import {
   type TimestampedLog,
   DISABLED_SOURCE,
 } from '../types.mts'
+import { homeyApiGet, homeyApiPut, homeyCallback } from './callback-api.mts'
 import { createDirtyGate } from './dirty-gate.mts'
 
 // Give slow transports a real chance while keeping the loading overlay
@@ -90,20 +91,6 @@ const fireAndForget = (
 ): void => {
   forget(promise, onError)
 }
-
-// Promisifies Homey Settings API callbacks (error-first convention)
-const homeyCallback = async <T,>(
-  call: (callback: (error: Error | null, result: T) => void) => void,
-): Promise<T> =>
-  new Promise((resolve, reject) => {
-    call((error, result) => {
-      if (error !== null) {
-        reject(error)
-        return
-      }
-      resolve(result)
-    })
-  })
 
 const getElement = <T extends HTMLElement>(
   id: string,
@@ -355,12 +342,12 @@ const handleSettings = (settings: HomeySettings): void => {
 }
 
 const fetchLanguage = async (homey: Homey): Promise<void> => {
-  document.documentElement.lang = await homeyCallback<string>((callback) => {
-    homey.api('GET', '/language', callback)
-  })
+  document.documentElement.lang = await homeyApiGet<string>(homey, '/language')
 }
 
-const fetchHomeySettings = async (homey: Homey): Promise<void> => {
+// `load`, not `fetch`: this reads the settings STORE (`homey.get`), not
+// the app API — the `fetch*` prefix is reserved for transport calls.
+const loadHomeySettings = async (homey: Homey): Promise<void> => {
   try {
     const settings = await homeyCallback<HomeySettings>((callback) => {
       homey.get(callback)
@@ -382,9 +369,7 @@ const fetchListOrEmpty = async <T,>(
   path: string,
 ): Promise<T[]> => {
   try {
-    return await homeyCallback<T[]>((callback) => {
-      homey.api('GET', path, callback)
-    })
+    return await homeyApiGet<T[]>(homey, path)
   } catch (error) {
     if (!isNotFound(error)) {
       await homey.alert(getErrorMessage(error))
@@ -719,17 +704,10 @@ const getSelectedSources = (): OutdoorSources =>
 const autoAdjustCooling = async (homey: Homey): Promise<void> =>
   dirtyGate.runBusy(async () => {
     try {
-      await homeyCallback<undefined>((callback) => {
-        homey.api(
-          'PUT',
-          '/melcloud/cooling/auto_adjustment',
-          {
-            isEnabled: enabledElement.value === 'true',
-            outdoorSources: getSelectedSources(),
-          } satisfies TemperatureListenerData,
-          callback,
-        )
-      })
+      await homeyApiPut(homey, '/cooling/auto-adjustment', {
+        isEnabled: enabledElement.value === 'true',
+        outdoorSources: getSelectedSources(),
+      } satisfies TemperatureListenerData)
       dirtyGate.markSaved()
     } catch (error) {
       await homey.alert(getErrorMessage(error))
@@ -741,7 +719,7 @@ const autoAdjustCooling = async (homey: Homey): Promise<void> =>
 const refreshAll = async (homey: Homey): Promise<void> =>
   dirtyGate.runBusy(async () => {
     await populateSources(homey)
-    await fetchHomeySettings(homey)
+    await loadHomeySettings(homey)
     dirtyGate.markSaved()
   })
 

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -113,6 +113,18 @@ describe('api', () => {
 
       expect(autoAdjustCooling).toHaveBeenCalledWith(body)
     })
+
+    it('should serve the frozen legacy path through the same handler', async () => {
+      const { autoAdjustCooling, homey } = createHomeyContext({
+        melcloudDevices: [],
+        temperatureSensors: [],
+      })
+      const body = { isEnabled: false, outdoorSources: {} }
+
+      await api.autoAdjustCoolingLegacy({ body, homey })
+
+      expect(autoAdjustCooling).toHaveBeenCalledWith(body)
+    })
   })
 
   describe('getAdjustableGroups', () => {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -134,6 +134,21 @@ describe(MELCloudExtensionApp, () => {
 
     await advancePastInit()
 
+    expect(mockHomey.apiAppGet).toHaveBeenCalledWith('/devices/groups')
+    expect(app.deviceGroups).toStrictEqual(groups)
+  })
+
+  it('should fall back to the frozen legacy grouping path on an older com.melcloud', async () => {
+    const { classicDevice } = createDevices()
+    const groups = [{ deviceIds: ['classic-1'], name: 'Domicile' }]
+    const { app, mockHomey } = await createHarness([classicDevice])
+    mockHomey.apiAppGet.mockImplementationOnce(() => {
+      throw new Error('Not Found')
+    })
+    mockHomey.apiAppGet.mockReturnValue(groups)
+
+    await advancePastInit()
+
     expect(mockHomey.apiAppGet).toHaveBeenCalledWith('/device_groups')
     expect(app.deviceGroups).toStrictEqual(groups)
   })


### PR DESCRIPTION
Part of the family-wide API-surface harmonization (sibling PRs on com.melcloud and com.heatzy).

- **`settings/callback-api.mts`** — byte-identical tri-repo transport adopted; local `homeyCallback` and raw `homey.api` calls retired (`homeyCallback` stays imported for the settings-STORE read, renamed `loadHomeySettings` — `fetch*` is reserved for transport).
- **`PUT /cooling/auto-adjustment`** — the only snake_case + vendor-segment path goes kebab-case REST; **the old path stays as `autoAdjustCoolingLegacy`** (cached pre-rename bundles still PUT it — frozen, documented).
- **Cross-app probe** — `/devices/groups` first, fallback to the frozen `/device_groups` for an older com.melcloud: rides out version skew without release coordination. Fallback covered by a dedicated test.

Full suite green (122 tests). Wire changes are additive only (new routes + kept aliases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)