### PR TITLE
test: pin the API surface (contract + route guards)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,13 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
   frozen `/device_groups` (an older com.melcloud during version skew).
   `settings/callback-api.mts` is the settings page's transport
   (error-first-callback SDK), a byte-identical copy of com.melcloud's
-  (com.heatzy carries the third) — edit all three together.
+  (com.heatzy carries the third) — edit all three together. The surface
+  is test-pinned in two halves, one file each — extend BOTH when
+  touching a route: `tests/unit/api-contract.test.ts` pins manifest
+  ids ↔ handlers both ways plus the handlers' function type;
+  `tests/unit/api-route-guards.test.ts` pins the call sites (every
+  settings path literal must match a declared route) and the frozen
+  legacy route.
 - Dirty-gating: `settings/dirty-gate.mts` is the ONE primitive behind the
   Update/Refresh pair — never re-derive its invariant at a call site. Its
   `serialize` must stay a PURE form snapshot, never a request-body

--- a/tests/unit/api-contract.test.ts
+++ b/tests/unit/api-contract.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import appConfig from '../../.homeycompose/app.json' with { type: 'json' }
+import api from '../../api.mts'
+
+const sortedKeys = (object: object): string[] =>
+  Object.keys(object).toSorted((left, right) => left.localeCompare(right))
+
+describe('api contract', () => {
+  it.each(Object.keys(appConfig.api))(
+    '%s handler exists in api.mts',
+    (name) => {
+      expect(api).toHaveProperty(name)
+    },
+  )
+
+  // The compile-time half of the contract, asserted on the whole union
+  // at once: no per-name method reference ever leaves its object
+  // (unbound-method).
+  it('should expose only function handlers', () => {
+    expectTypeOf<(typeof api)[keyof typeof api]>().toBeFunction()
+  })
+
+  it('should not have handlers missing from app.json', () => {
+    expect(sortedKeys(api)).toStrictEqual(sortedKeys(appConfig.api))
+  })
+})

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -1,0 +1,93 @@
+import { readdir, readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+interface DeclaredRoute {
+  readonly method: string
+  readonly path: string
+}
+
+// The call-site half of the API contract: the settings webview may only
+// call routes the app manifest declares. Literal paths are extracted
+// from the sources and checked against the declared table;
+// template-built paths are out of scope by design. The declaration half
+// (manifest ids ↔ handlers, both directions, type level) lives in
+// api-contract.test.ts. The cross-app probes in app.mts target
+// com.melcloud's routes, not this app's — out of scope here.
+const SOURCE_DIRS: readonly string[] = ['settings']
+
+const readRoutes = async (): Promise<DeclaredRoute[]> => {
+  const manifest = JSON.parse(
+    await readFile('.homeycompose/app.json', 'utf8'),
+  ) as { api?: Record<string, DeclaredRoute> }
+  return Object.values(manifest.api ?? {})
+}
+
+const listSourceFiles = async (dir: string): Promise<string[]> => {
+  const entries = await readdir(dir)
+  return entries
+    .filter((entry) => entry.endsWith('.mts') || entry.endsWith('.html'))
+    .map((entry) => `${dir}/${entry}`)
+}
+
+// Comment lines are dropped so a path mentioned in prose is not read as
+// a call site.
+const stripComments = (source: string): string =>
+  source
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trimStart()
+      return (
+        !trimmed.startsWith('//') &&
+        !trimmed.startsWith('*') &&
+        !trimmed.startsWith('/*')
+      )
+    })
+    .join('\n')
+
+const extractPathLiterals = (source: string): string[] =>
+  stripComments(source)
+    .matchAll(/['"](?<path>\/[a-z][\w\-\/]*)['"]/gv)
+    .map((match) => match.groups?.path ?? '')
+    .toArray()
+
+const routeMatches = (routePath: string, literal: string): boolean => {
+  const routeSegments = routePath.split('/')
+  const literalSegments = literal.split('/')
+  return (
+    routeSegments.length === literalSegments.length &&
+    routeSegments.every(
+      (segment, index) =>
+        segment.startsWith(':') || segment === literalSegments[index],
+    )
+  )
+}
+
+describe('api route guards', () => {
+  it('should declare every path the settings webview calls', async () => {
+    const routes = await readRoutes()
+    const fileGroups = await Promise.all(
+      SOURCE_DIRS.map(async (dir) => listSourceFiles(dir)),
+    )
+    const sources = await Promise.all(
+      fileGroups.flat().map(async (file) => readFile(file, 'utf8')),
+    )
+    const literals = sources.flatMap((source) => extractPathLiterals(source))
+    const unmatched = [...new Set(literals)].filter((literal) =>
+      routes.every((route) => !routeMatches(route.path, literal)),
+    )
+
+    expect(unmatched).toStrictEqual([])
+  })
+
+  it('should keep the frozen legacy route declared for cached bundles', async () => {
+    const manifest = JSON.parse(
+      await readFile('.homeycompose/app.json', 'utf8'),
+    ) as { api: Record<string, DeclaredRoute> }
+
+    expect(manifest.api.autoAdjustCoolingLegacy).toStrictEqual({
+      method: 'PUT',
+      path: '/melcloud/cooling/auto_adjustment',
+    })
+  })
+})


### PR DESCRIPTION
Clones com.melcloud's two-half API-surface pinning (sibling PRs on the two other apps): `api-contract.test.ts` (manifest ids ↔ handlers both ways + type level) and `api-route-guards.test.ts` (every settings path literal must match a declared route, plus the frozen legacy `PUT /melcloud/cooling/auto_adjustment` pin). Doctrine documented in CLAUDE.md. Suite green (132 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)