### PR TITLE
feat: half-degree precision on the cooling efficiency floor

### DIFF
--- a/listeners/melcloud.mts
+++ b/listeners/melcloud.mts
@@ -14,6 +14,15 @@ const THERMOSTAT_MODE = 'thermostat_mode'
 const DEFAULT_TEMPERATURE = 0
 // Minimum gap between outdoor temperature and target cooling temperature
 const GAP_TEMPERATURE = 8
+
+// MELCloud accepts half-degree setpoints: ceiling to the next 0.5 °C
+// keeps the floor as close as the wire allows to the real outdoor
+// reading, still never letting the setpoint sit more than
+// GAP_TEMPERATURE below it.
+const SETPOINT_STEP = 0.5
+
+const ceilToSetpointStep = (value: number): number =>
+  Math.ceil(value / SETPOINT_STEP) * SETPOINT_STEP
 // Fallback ceiling when the capability options do not advertise a max
 // (both MELCloud ATA drivers ship `target_temperature` with max 31 °C)
 const MAX_TEMPERATURE = 31
@@ -157,7 +166,8 @@ export class MELCloudListener {
     return Math.min(
       Math.max(
         this.#getThreshold(),
-        Math.ceil(this.#source.value ?? DEFAULT_TEMPERATURE) - GAP_TEMPERATURE,
+        ceilToSetpointStep(this.#source.value ?? DEFAULT_TEMPERATURE) -
+          GAP_TEMPERATURE,
       ),
       this.#getMaxTemperature(),
     )

--- a/tests/unit/melcloud-listener.test.ts
+++ b/tests/unit/melcloud-listener.test.ts
@@ -135,7 +135,7 @@ describe(MELCloudListener, () => {
     expect(harness.listener.isCooling).toBe(false)
   })
 
-  it('should floor the target to the outdoor temperature minus the gap', async () => {
+  it('should floor the target to the outdoor temperature minus the gap, half-degree precise', async () => {
     const harness = createHarness({
       outdoorTemperature: 34.2,
       targetTemperature: 23,
@@ -143,9 +143,24 @@ describe(MELCloudListener, () => {
 
     await harness.listener.listenToThermostatMode()
 
+    // 34.2 ceils to the wire's next half degree (34.5), not to 35: the
+    // floor hugs the outdoor reading while the gap stays <= 8.
     expect(
       getInstance(harness, 'target_temperature').setValue,
-    ).toHaveBeenCalledWith(27)
+    ).toHaveBeenCalledWith(26.5)
+  })
+
+  it('should keep a whole-degree outdoor reading on whole degrees', async () => {
+    const harness = createHarness({
+      outdoorTemperature: 34,
+      targetTemperature: 23,
+    })
+
+    await harness.listener.listenToThermostatMode()
+
+    expect(
+      getInstance(harness, 'target_temperature').setValue,
+    ).toHaveBeenCalledWith(26)
   })
 
   it('should cap the target at the capability maximum', async () => {


### PR DESCRIPTION
Per request: the 8 °C efficiency gap targeted a whole-degree ceiling of the outdoor reading; MELCloud accepts half-degree setpoints, so the floor now ceils to the next **0.5 °C** — e.g. outdoor 34.2 °C targets 26.5 °C instead of 27 °C, gap still ≤ 8 °C. Covered by an updated fixture (34.2 → 26.5) plus a whole-degree case. Suite green (133 tests, 100 % backend coverage held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)