### PR TITLE
fix: read the 2019 firmware's not-found shape as endpoint absent

### DIFF
--- a/settings/index.mts
+++ b/settings/index.mts
@@ -358,8 +358,14 @@ const loadHomeySettings = async (homey: Homey): Promise<void> => {
   }
 }
 
-const isNotFound = (error: unknown): boolean =>
-  getErrorMessage(error) === 'notFound'
+// Two wire shapes for a missing endpoint: com.melcloud's own
+// NotFoundError serializes as 'notFound', while the Homey Pro 2019
+// firmware's API bridge answers 'Not found: GET /api/app/…' — both must
+// read as "endpoint absent", not as an alert-worthy failure.
+const isNotFound = (error: unknown): boolean => {
+  const message = getErrorMessage(error)
+  return message === 'notFound' || message.startsWith('Not found')
+}
 
 // Shared GET-or-empty policy of the two device lists: a 404 (endpoint
 // absent — an older com.melcloud) silently reads as "none", any other


### PR DESCRIPTION
Seen live on a Homey Pro 2019: the settings page alerted `Not found: GET /api/app/com.mecloud.extension/devices/sensors/temperature` — that firmware's API bridge phrases a missing app route as `Not found: GET …`, which `isNotFound` (expecting com.melcloud's own `notFound`) did not recognize, so the designed silent degradation alerted instead. Both shapes now read as "endpoint absent". Suite green (133 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)