### PR TITLE
refactor!: drop the legacy auto-adjustment route and grouping fallback

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -4,10 +4,6 @@
       "method": "PUT",
       "path": "/cooling/auto-adjustment"
     },
-    "autoAdjustCoolingLegacy": {
-      "method": "PUT",
-      "path": "/melcloud/cooling/auto_adjustment"
-    },
     "getAdjustableGroups": {
       "method": "GET",
       "path": "/devices/groups"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ to judge success.
   the temperature sensors, debounces device events, and owns the
   per-device `MELCloudListener`s plus the shared `OutdoorSource`
   registry.
-- Device grouping — com.melcloud exposes `GET /device_groups`
+- Device grouping — com.melcloud exposes `GET /devices/groups`
   (`[{ deviceIds, name }]`, one entry per MELCloud building, both
   dialects, sorted by name). The extension declares the
   `homey:app:com.mecloud` permission and calls the endpoint through
@@ -135,12 +135,12 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
   commit the CLI-generated outputs verbatim (no trailing newline).
 - App-API surface conventions (aligned on com.melcloud): paths are
   kebab-case REST, `get*` for GET; `fetch*` in the webview is reserved
-  for transport calls (`load*` reads the settings store). The current
-  auto-adjustment path is `/cooling/auto-adjustment`;
-  `/melcloud/cooling/auto_adjustment` (`autoAdjustCoolingLegacy`) is
-  FROZEN — cached pre-rename bundles still PUT it, never remove it.
-  The com.melcloud grouping is probed `/devices/groups` first, then the
-  frozen `/device_groups` (an older com.melcloud during version skew).
+  for transport calls (`load*` reads the settings store). The
+  auto-adjustment path is `/cooling/auto-adjustment` (the snake_case
+  legacy alias was dropped by decision, 2026-07 — a cached pre-rename
+  bundle now alerts on Apply until it refreshes). The com.melcloud
+  grouping is `GET /devices/groups` only; an older com.melcloud reads
+  as "no grouping" (the sanitizer's degradation path).
   `settings/callback-api.mts` is the settings page's transport
   (error-first-callback SDK), a byte-identical copy of com.melcloud's
   (com.heatzy carries the third) — edit all three together. The surface
@@ -148,8 +148,7 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
   touching a route: `tests/unit/api-contract.test.ts` pins manifest
   ids ↔ handlers both ways plus the handlers' function type;
   `tests/unit/api-route-guards.test.ts` pins the call sites (every
-  settings path literal must match a declared route) and the frozen
-  legacy route.
+  settings path literal must match a declared route).
 - Dirty-gating: `settings/dirty-gate.mts` is the ONE primitive behind the
   Update/Refresh pair — never re-derive its invariant at a call site. Its
   `serialize` must stay a PURE form snapshot, never a request-body

--- a/api.mts
+++ b/api.mts
@@ -36,20 +36,6 @@ const api = {
     await app.autoAdjustCooling(body)
   },
   /**
-   * Serves the frozen legacy path `/melcloud/cooling/auto_adjustment`:
-   * phone webviews cache the settings bundle across app versions, so a
-   * pre-rename bundle still PUTs here — never remove it.
-   * @param context - Homey API context.
-   * @param context.body - Selected outdoor source and enablement flag.
-   * @param context.homey - Homey instance carrying the app.
-   */
-  async autoAdjustCoolingLegacy(context: {
-    body: TemperatureListenerData
-    homey: Homey
-  }): Promise<void> {
-    await api.autoAdjustCooling(context)
-  },
-  /**
    * Lists the settings rows: one named group per MELCloud building
    * (com.melcloud's inter-app grouping), unmatched devices trailing in
    * an unnamed group, or a single unnamed flat group when no grouping

--- a/app.json
+++ b/app.json
@@ -5,10 +5,6 @@
       "method": "PUT",
       "path": "/cooling/auto-adjustment"
     },
-    "autoAdjustCoolingLegacy": {
-      "method": "PUT",
-      "path": "/melcloud/cooling/auto_adjustment"
-    },
     "getAdjustableGroups": {
       "method": "GET",
       "path": "/devices/groups"

--- a/app.mts
+++ b/app.mts
@@ -214,20 +214,10 @@ export default class MELCloudExtensionApp extends App {
 
   async #fetchDeviceGroups(): Promise<DeviceGroups | null> {
     try {
-      return toDeviceGroups(await this.#fetchDeviceGroupsPayload())
+      const payload: unknown = await this.#melcloudApp.get('/devices/groups')
+      return toDeviceGroups(payload)
     } catch {
       return null
-    }
-  }
-
-  // com.melcloud serves the grouping on `/devices/groups` and keeps the
-  // frozen legacy `/device_groups` alias; probing new-then-legacy rides
-  // out version skew between the two independently-updated apps.
-  async #fetchDeviceGroupsPayload(): Promise<unknown> {
-    try {
-      return await this.#melcloudApp.get('/devices/groups')
-    } catch {
-      return this.#melcloudApp.get('/device_groups')
     }
   }
 

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -79,15 +79,4 @@ describe('api route guards', () => {
 
     expect(unmatched).toStrictEqual([])
   })
-
-  it('should keep the frozen legacy route declared for cached bundles', async () => {
-    const manifest = JSON.parse(
-      await readFile('.homeycompose/app.json', 'utf8'),
-    ) as { api: Record<string, DeclaredRoute> }
-
-    expect(manifest.api.autoAdjustCoolingLegacy).toStrictEqual({
-      method: 'PUT',
-      path: '/melcloud/cooling/auto_adjustment',
-    })
-  })
 })

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -113,18 +113,6 @@ describe('api', () => {
 
       expect(autoAdjustCooling).toHaveBeenCalledWith(body)
     })
-
-    it('should serve the frozen legacy path through the same handler', async () => {
-      const { autoAdjustCooling, homey } = createHomeyContext({
-        melcloudDevices: [],
-        temperatureSensors: [],
-      })
-      const body = { isEnabled: false, outdoorSources: {} }
-
-      await api.autoAdjustCoolingLegacy({ body, homey })
-
-      expect(autoAdjustCooling).toHaveBeenCalledWith(body)
-    })
   })
 
   describe('getAdjustableGroups', () => {

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -138,21 +138,6 @@ describe(MELCloudExtensionApp, () => {
     expect(app.deviceGroups).toStrictEqual(groups)
   })
 
-  it('should fall back to the frozen legacy grouping path on an older com.melcloud', async () => {
-    const { classicDevice } = createDevices()
-    const groups = [{ deviceIds: ['classic-1'], name: 'Domicile' }]
-    const { app, mockHomey } = await createHarness([classicDevice])
-    mockHomey.apiAppGet.mockImplementationOnce(() => {
-      throw new Error('Not Found')
-    })
-    mockHomey.apiAppGet.mockReturnValue(groups)
-
-    await advancePastInit()
-
-    expect(mockHomey.apiAppGet).toHaveBeenCalledWith('/device_groups')
-    expect(app.deviceGroups).toStrictEqual(groups)
-  })
-
   it('should stamp the legacy weather default on the first seeding', async () => {
     const { classicDevice } = createDevices()
     const { mockHomey } = await createHarness([classicDevice])


### PR DESCRIPTION
Decided cleanup, sibling of OlivierZal/com.melcloud#1480:
- **`PUT /melcloud/cooling/auto_adjustment`** (`autoAdjustCoolingLegacy`) removed — a cached pre-rename settings bundle now alerts on Apply until it refreshes (accepted).
- **Grouping probe** calls `GET /devices/groups` only; an older com.melcloud degrades to «no grouping» via the sanitizer instead of a legacy retry.
- Tests and CLAUDE.md doctrine updated accordingly (frozen-route pins removed). Suite green (129 tests, 100 % backend coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)