### PR TITLE
style: drop the bespoke export-type lint rule for documented doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,14 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
 - `useDefineForClassFields` wipes fields assigned by `super()`: a
   subclass re-declaring an Error option (like `cause`) must use
   `declare`, not a field initializer.
+- All-type exports hoist the keyword (`export type { A, B }`); mixed
+  exports keep inline `type` specifiers, mirroring the
+  inline-type-imports style. No shipped rule enforces the export side
+  (`consistent-type-exports` tolerates inline specifiers once present;
+  `import-x/consistent-type-specifier-style` covers imports only): the
+  convention is maintained by hand, in review — a bespoke
+  `no-restricted-syntax` selector for it was removed by decision
+  (2026-07-28).
 
 ## Repo process
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -482,18 +482,6 @@ const config = defineConfig([
       'no-object-constructor': 'error',
       'no-param-reassign': 'error',
       'no-promise-executor-return': 'error',
-      // `consistent-type-exports` tolerates inline specifiers on all-type
-      // exports; no shipped rule hoists them, so the constraint is spelled
-      // out here (imports get the same via `consistent-type-imports`).
-      'no-restricted-syntax': [
-        'error',
-        {
-          message:
-            'An all-type export hoists the keyword: `export type { … }`.',
-          selector:
-            "ExportNamedDeclaration[exportKind='value']:has(ExportSpecifier[exportKind='type']):not(:has(ExportSpecifier[exportKind='value']))",
-        },
-      ],
       'no-return-assign': ['error', 'always'],
       'no-self-compare': 'error',
       'no-sequences': [


### PR DESCRIPTION
Replaces the bespoke `no-restricted-syntax` selector (merged earlier, rejected by decision) with documented doctrine in CLAUDE.md: all-type exports hoist the keyword, mixed exports keep inline specifiers, maintained by hand in review. The codebase already complies; format, lint, typecheck and tests are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)