### PR TITLE
test: pin the HTTP method of every call site, and account for them all

### DIFF
--- a/tests/unit/api-contract.test.ts
+++ b/tests/unit/api-contract.test.ts
@@ -6,14 +6,12 @@ import api from '../../api.mts'
 const sortedKeys = (object: object): string[] =>
   Object.keys(object).toSorted((left, right) => left.localeCompare(right))
 
+// One equality pins the ids <-> handlers mapping in both directions at
+// once: a handler with no declaration and a declaration with no handler
+// both break it, and the diff names the offender. A per-id existence
+// sweep alongside it could only ever fail together with the equality,
+// so it is not kept.
 describe('api contract', () => {
-  it.each(Object.keys(appConfig.api))(
-    '%s handler exists in api.mts',
-    (name) => {
-      expect(api).toHaveProperty(name)
-    },
-  )
-
   // The compile-time half of the contract, asserted on the whole union
   // at once: no per-name method reference ever leaves its object
   // (unbound-method).
@@ -21,7 +19,7 @@ describe('api contract', () => {
     expectTypeOf<(typeof api)[keyof typeof api]>().toBeFunction()
   })
 
-  it('should not have handlers missing from app.json', () => {
+  it('should declare exactly the handlers app.json names', () => {
     expect(sortedKeys(api)).toStrictEqual(sortedKeys(appConfig.api))
   })
 })

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -51,6 +51,54 @@ const extractPathLiterals = (source: string): string[] =>
     .map((match) => match.groups?.path ?? '')
     .toArray()
 
+// The typed helpers carry the verb in their name; the boot beacon calls
+// the raw SDK with the verb as its first argument. No declared path of
+// this app is served under two verbs today, so the pair check guards
+// against the collision arriving rather than one already there — the
+// sibling apps each have one (`/sessions` under three verbs in
+// com.heatzy), and a call under an unserved verb 404s the same way.
+const HELPER_CALL =
+  /homeyApi(?<verb>Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(\s*[\w.#]+\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
+const SDK_CALL =
+  /homey\.api\(\s*['"](?<verb>[A-Z]+)['"]\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
+
+// Every helper call site, whatever shape its path takes: the sweeps
+// above only prove they found something, this proves they found
+// everything.
+const HELPER_CALL_SITE = /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(/gv
+
+// `fetchListOrEmpty` takes its path as a parameter and is called with
+// literals one hop up, where the bare-path sweep reads them. Counting
+// it keeps the accounting complete: a second such helper would show up
+// as a shortfall rather than slipping past unread.
+const HELPER_INDIRECT_CALL =
+  /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(\s*[\w.#]+\s*,\s*[a-z]\w*/gv
+
+const extractRouteCalls = (source: string): DeclaredRoute[] => {
+  const stripped = stripComments(source)
+  return [
+    ...stripped.matchAll(HELPER_CALL).map((match) => ({
+      method: (match.groups?.verb ?? '').toUpperCase(),
+      path: match.groups?.path ?? '',
+    })),
+    ...stripped.matchAll(SDK_CALL).map((match) => ({
+      method: match.groups?.verb ?? '',
+      path: match.groups?.path ?? '',
+    })),
+  ]
+}
+
+const countMatches = (source: string, pattern: RegExp): number =>
+  stripComments(source).matchAll(pattern).toArray().length
+
+const dedupeCalls = (calls: DeclaredRoute[]): DeclaredRoute[] => {
+  const byPair = new Map<string, DeclaredRoute>()
+  for (const call of calls) {
+    byPair.set(`${call.method} ${call.path}`, call)
+  }
+  return byPair.values().toArray()
+}
+
 const routeMatches = (routePath: string, literal: string): boolean => {
   const routeSegments = routePath.split('/')
   const literalSegments = literal.split('/')
@@ -63,20 +111,57 @@ const routeMatches = (routePath: string, literal: string): boolean => {
   )
 }
 
+const readSources = async (): Promise<string[]> => {
+  const fileGroups = await Promise.all(
+    SOURCE_DIRS.map(async (dir) => listSourceFiles(dir)),
+  )
+  return Promise.all(
+    fileGroups.flat().map(async (file) => readFile(file, 'utf8')),
+  )
+}
+
 describe('api route guards', () => {
   it('should declare every path the settings webview calls', async () => {
     const routes = await readRoutes()
-    const fileGroups = await Promise.all(
-      SOURCE_DIRS.map(async (dir) => listSourceFiles(dir)),
-    )
-    const sources = await Promise.all(
-      fileGroups.flat().map(async (file) => readFile(file, 'utf8')),
-    )
+    const sources = await readSources()
     const literals = sources.flatMap((source) => extractPathLiterals(source))
     const unmatched = [...new Set(literals)].filter((literal) =>
       routes.every((route) => !routeMatches(route.path, literal)),
     )
 
     expect(unmatched).toStrictEqual([])
+  })
+
+  it('should declare every method the settings webview calls each path with', async () => {
+    const routes = await readRoutes()
+    const sources = await readSources()
+    const calls = sources.flatMap((source) => extractRouteCalls(source))
+    const unmatched = dedupeCalls(calls).filter((call) =>
+      routes.every(
+        (route) =>
+          route.method !== call.method || !routeMatches(route.path, call.path),
+      ),
+    )
+
+    expect(unmatched).toStrictEqual([])
+  })
+
+  // The checks above pass vacuously on a call the extractors cannot
+  // read. Accounting for every call site — parsed, or the one helper
+  // taking its path as a parameter — turns that silence into a failure.
+  it('should account for every helper call site', async () => {
+    const sources = await readSources()
+    const callSites = sources.reduce(
+      (total, source) => total + countMatches(source, HELPER_CALL_SITE),
+      0,
+    )
+    const indirectCalls = sources.reduce(
+      (total, source) => total + countMatches(source, HELPER_INDIRECT_CALL),
+      0,
+    )
+    const parsed = sources.flatMap((source) => extractRouteCalls(source)).length
+
+    expect(callSites).toBeGreaterThan(0)
+    expect(parsed + indirectCalls).toBeGreaterThanOrEqual(callSites)
   })
 })


### PR DESCRIPTION
## What

Brings this app's route guard up to the family's, found while reviewing the contract tests across the five repos.

## Why

**This app never got the method half.** `com.melcloud` #1491 and `com.heatzy` #1049 both fixed a guard that parsed the verb and then compared path segments only; here the verb was never read at all. Verified by mutation: turning the `/cooling/auto-adjustment` `homeyApiPut` into `homeyApiPost` passed the whole suite before this change, and fails it now.

Unlike the siblings, no declared path here is served under two verbs (`com.heatzy` has `/sessions` under three), so the pair check guards against that arriving rather than against a live collision — a call under an unserved verb 404s either way, and the comment says so.

**The completeness invariant is com.heatzy's**, and it is the reason its guard cannot go blind: every `homeyApi*` call site must be parsed, or be the one helper (`fetchListOrEmpty`) that takes its path as a parameter and is called with literals a hop up, where the bare-path sweep already reads them. Without it both checks pass vacuously on any call the extractors cannot read — which is exactly how the verb went unchecked in the first place.

## Also

The per-id existence sweep in `api-contract.test.ts` is removed: it could only ever fail together with the key equality beside it, which already pins the mapping in both directions and names the offender in its diff.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (126 tests, coverage 100%)
- [x] `npm run homey:validate` passes at `publish` level