### PR TITLE
test: adopt the shared route-guard kernel

### DIFF
--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -7,19 +7,35 @@ interface DeclaredRoute {
   readonly path: string
 }
 
+interface Surface {
+  readonly manifest: string
+  readonly name: string
+  readonly sourceDirs: readonly string[]
+}
+
 // The call-site half of the API contract: the settings webview may only
-// call routes the app manifest declares. Literal paths are extracted
-// from the sources and checked against the declared table;
-// template-built paths are out of scope by design. The declaration half
+// call routes the app manifest declares. Paths are extracted from the
+// sources — literal ones exactly, template-built ones by their fixed
+// chunks — and checked against the declared table. The declaration half
 // (manifest ids ↔ handlers, both directions, type level) lives in
 // api-contract.test.ts. The cross-app probes in app.mts target
 // com.melcloud's routes, not this app's — out of scope here.
-const SOURCE_DIRS: readonly string[] = ['settings']
+const SURFACES: readonly Surface[] = [
+  {
+    manifest: '.homeycompose/app.json',
+    name: 'settings',
+    sourceDirs: ['settings'],
+  },
+]
 
-const readRoutes = async (): Promise<DeclaredRoute[]> => {
-  const manifest = JSON.parse(
-    await readFile('.homeycompose/app.json', 'utf8'),
-  ) as { api?: Record<string, DeclaredRoute> }
+// Everything below the SURFACES table is the shared guard, byte-identical
+// in com.melcloud, com.heatzy and com.melcloud.extension — edit all three
+// together. Only the table above differs: it names what each app exposes.
+
+const readRoutes = async (manifestPath: string): Promise<DeclaredRoute[]> => {
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+    api?: Record<string, DeclaredRoute>
+  }
   return Object.values(manifest.api ?? {})
 }
 
@@ -51,28 +67,28 @@ const extractPathLiterals = (source: string): string[] =>
     .map((match) => match.groups?.path ?? '')
     .toArray()
 
+// Path-shaped template literals are swept wherever they are written,
+// not just inside a call: a builder returning one of several templates
+// puts them a function away from any verb, and they would otherwise be
+// the only paths nothing checks.
+const extractPathTemplates = (source: string): string[] =>
+  stripComments(source)
+    .matchAll(/`(?<template>\/[a-z][^`]*)`/gv)
+    .map((match) => match.groups?.template ?? '')
+    .toArray()
+
 // The typed helpers carry the verb in their name; the boot beacon calls
-// the raw SDK with the verb as its first argument. No declared path of
-// this app is served under two verbs today, so the pair check guards
-// against the collision arriving rather than one already there — the
-// sibling apps each have one (`/sessions` under three verbs in
-// com.heatzy), and a call under an unserved verb 404s the same way.
+// the raw SDK with the verb as its first argument. Reading the pair
+// matters because eleven declared paths differ only by method —
+// `/classic/sessions` alone is declared under POST, GET and DELETE. The
+// helper name must be followed immediately by its generic or its paren,
+// so the import list is not read as a call site. Template-built paths
+// are swept separately below; a path passed as a variable stays out of
+// scope, exactly as for the bare-path sweep above.
 const HELPER_CALL =
-  /homeyApi(?<verb>Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(\s*[\w.#]+\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
+  /homeyApi(?<verb>Get|Put|Post|Delete)(?:<[^\(\)]*>)?\(\s*[\w.#]+\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
 const SDK_CALL =
   /homey\.api\(\s*['"](?<verb>[A-Z]+)['"]\s*,\s*['"](?<path>\/[a-z][\w\-\/]*)['"]/gv
-
-// Every helper call site, whatever shape its path takes: the sweeps
-// above only prove they found something, this proves they found
-// everything.
-const HELPER_CALL_SITE = /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(/gv
-
-// `fetchListOrEmpty` takes its path as a parameter and is called with
-// literals one hop up, where the bare-path sweep reads them. Counting
-// it keeps the accounting complete: a second such helper would show up
-// as a shortfall rather than slipping past unread.
-const HELPER_INDIRECT_CALL =
-  /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(\s*[\w.#]+\s*,\s*[a-z]\w*/gv
 
 const extractRouteCalls = (source: string): DeclaredRoute[] => {
   const stripped = stripComments(source)
@@ -87,6 +103,100 @@ const extractRouteCalls = (source: string): DeclaredRoute[] => {
     })),
   ]
 }
+
+// Every PUT and DELETE call site builds its path from a template, so the
+// literal sweeps above see none of them — the verbs carrying the whole
+// settings surface would go unchecked. A template is still partly known
+// at build time: its literal chunks are fixed and ordered, and only the
+// `${…}` holes float (one may expand to nothing, as an optional query
+// string does). Keeping the chunks and letting the holes float is enough
+// to require that some declared route of the same method could serve the
+// call, which is the pair check's whole point.
+const HELPER_TEMPLATE_CALL =
+  /homeyApi(?<verb>Get|Put|Post|Delete)(?:<[^\(\)]*>)?\(\s*[\w.#]+\s*,\s*`(?<template>[^`]*)`/gv
+
+const escapeRegExp = (chunk: string): string =>
+  chunk.replaceAll(/[$\(\)*+.?\[\\\]^\{\|\}]/gv, String.raw`\$&`)
+
+// A hole can nest braces — `${new URLSearchParams({ … })}` does — so the
+// literal chunks are found by tracking depth, not by a regex that would
+// stop at the first inner `}`. `${` is folded to one sentinel first so
+// the scan reads a single character per step.
+const HOLE = ''
+
+const toTemplateChunks = (template: string): string[] => {
+  const chunks: string[] = []
+  let literal = ''
+  let depth = 0
+  for (const char of template.replaceAll('${', '')) {
+    if (char === HOLE) {
+      if (depth === 0) {
+        chunks.push(literal)
+        literal = ''
+      }
+      depth += 1
+    } else if (char === '{' && depth > 0) {
+      depth += 1
+    } else if (char === '}' && depth > 0) {
+      depth -= 1
+    } else if (depth === 0) {
+      literal += char
+    }
+  }
+  chunks.push(literal)
+  return chunks
+}
+
+// Declared paths carry no query string, so anything from the first `?`
+// of a literal chunk on is dropped — a `?` inside a hole is part of the
+// hole and never reaches here.
+const toTemplatePattern = (template: string): RegExp => {
+  const chunks = toTemplateChunks(template)
+  const queryIndex = chunks.findIndex((chunk) => chunk.includes('?'))
+  const pathChunks =
+    queryIndex === -1
+      ? chunks
+      : [
+          ...chunks.slice(0, queryIndex),
+          (chunks[queryIndex] ?? '').split('?', 1)[0] ?? '',
+        ]
+  return new RegExp(
+    `^${pathChunks.map((chunk) => escapeRegExp(chunk)).join('.*')}$`,
+    'v',
+  )
+}
+
+interface TemplateCall {
+  readonly method: string
+  readonly pattern: RegExp
+  readonly template: string
+}
+
+const extractTemplateCalls = (source: string): TemplateCall[] =>
+  stripComments(source)
+    .matchAll(HELPER_TEMPLATE_CALL)
+    .map((match) => ({
+      method: (match.groups?.verb ?? '').toUpperCase(),
+      pattern: toTemplatePattern(match.groups?.template ?? ''),
+      template: match.groups?.template ?? '',
+    }))
+    .toArray()
+
+// Counting every helper call site, whatever shape its path takes, turns
+// the sweeps above from "found something" into "found everything": a
+// call the extractors cannot read shows up as a shortfall instead of
+// passing unseen. A generic may wrap across lines, so newlines are
+// allowed inside it.
+const HELPER_CALL_SITE = /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\s*\(/gv
+
+// Some call sites hand over a path the site itself does not spell: a
+// parameter on a list helper, or a builder returning one of several
+// templates. Their verb is unreadable there, but every path they can
+// produce is written somewhere in the same sources, which the sweep
+// below reads. Counting them keeps the accounting complete instead of
+// letting them vanish.
+const HELPER_INDIRECT_CALL =
+  /homeyApi(?:Get|Put|Post|Delete)(?:<[^\(\)]*>)?\(\s*[\w.#]+\s*,\s*[a-z]\w*/gv
 
 const countMatches = (source: string, pattern: RegExp): number =>
   stripComments(source).matchAll(pattern).toArray().length
@@ -111,9 +221,11 @@ const routeMatches = (routePath: string, literal: string): boolean => {
   )
 }
 
-const readSources = async (): Promise<string[]> => {
+const readSurfaceSources = async (
+  sourceDirs: readonly string[],
+): Promise<string[]> => {
   const fileGroups = await Promise.all(
-    SOURCE_DIRS.map(async (dir) => listSourceFiles(dir)),
+    sourceDirs.map(async (dir) => listSourceFiles(dir)),
   )
   return Promise.all(
     fileGroups.flat().map(async (file) => readFile(file, 'utf8')),
@@ -121,47 +233,80 @@ const readSources = async (): Promise<string[]> => {
 }
 
 describe('api route guards', () => {
-  it('should declare every path the settings webview calls', async () => {
-    const routes = await readRoutes()
-    const sources = await readSources()
-    const literals = sources.flatMap((source) => extractPathLiterals(source))
-    const unmatched = [...new Set(literals)].filter((literal) =>
-      routes.every((route) => !routeMatches(route.path, literal)),
-    )
+  describe.each(SURFACES)('$name', ({ manifest, sourceDirs }) => {
+    it('should declare every path its webview sources call', async () => {
+      const routes = await readRoutes(manifest)
+      const sources = await readSurfaceSources(sourceDirs)
+      const literals = sources.flatMap((source) => extractPathLiterals(source))
+      const templates = sources.flatMap((source) =>
+        extractPathTemplates(source),
+      )
+      const unmatched = [
+        ...[...new Set(literals)].filter((literal) =>
+          routes.every((route) => !routeMatches(route.path, literal)),
+        ),
+        ...[...new Set(templates)].filter((template) => {
+          const pattern = toTemplatePattern(template)
+          return routes.every((route) => !pattern.test(route.path))
+        }),
+      ]
 
-    expect(unmatched).toStrictEqual([])
-  })
+      expect(unmatched).toStrictEqual([])
+    })
 
-  it('should declare every method the settings webview calls each path with', async () => {
-    const routes = await readRoutes()
-    const sources = await readSources()
-    const calls = sources.flatMap((source) => extractRouteCalls(source))
-    const unmatched = dedupeCalls(calls).filter((call) =>
-      routes.every(
-        (route) =>
-          route.method !== call.method || !routeMatches(route.path, call.path),
-      ),
-    )
+    it('should declare every method its webview sources call each path with', async () => {
+      const routes = await readRoutes(manifest)
+      const sources = await readSurfaceSources(sourceDirs)
+      const calls = sources.flatMap((source) => extractRouteCalls(source))
+      const unmatched = dedupeCalls(calls).filter((call) =>
+        routes.every(
+          (route) =>
+            route.method !== call.method ||
+            !routeMatches(route.path, call.path),
+        ),
+      )
 
-    expect(unmatched).toStrictEqual([])
-  })
+      expect(unmatched).toStrictEqual([])
+    })
 
-  // The checks above pass vacuously on a call the extractors cannot
-  // read. Accounting for every call site — parsed, or the one helper
-  // taking its path as a parameter — turns that silence into a failure.
-  it('should account for every helper call site', async () => {
-    const sources = await readSources()
-    const callSites = sources.reduce(
-      (total, source) => total + countMatches(source, HELPER_CALL_SITE),
-      0,
-    )
-    const indirectCalls = sources.reduce(
-      (total, source) => total + countMatches(source, HELPER_INDIRECT_CALL),
-      0,
-    )
-    const parsed = sources.flatMap((source) => extractRouteCalls(source)).length
+    it('should declare a route of the same method for every template-built call', async () => {
+      const routes = await readRoutes(manifest)
+      const sources = await readSurfaceSources(sourceDirs)
+      const calls = sources.flatMap((source) => extractTemplateCalls(source))
+      const unmatched = calls
+        .filter((call) =>
+          routes.every(
+            (route) =>
+              route.method !== call.method || !call.pattern.test(route.path),
+          ),
+        )
+        .map(({ method, template }) => `${method} ${template}`)
 
-    expect(callSites).toBeGreaterThan(0)
-    expect(parsed + indirectCalls).toBeGreaterThanOrEqual(callSites)
+      expect(unmatched).toStrictEqual([])
+    })
+
+    // Both checks above pass vacuously on a call the extractors cannot
+    // read, which is how the verb went unchecked in the first place.
+    // Accounting for every call site — parsed, or handing over a path it
+    // does not spell — turns that silence into a failure, and subsumes
+    // any "the extractor still matches something" clause: a regex that
+    // stopped matching leaves its calls counted here and nowhere else.
+    it('should account for every helper call site in its own sources', async () => {
+      const sources = await readSurfaceSources(sourceDirs)
+      const callSites = sources.reduce(
+        (total, source) => total + countMatches(source, HELPER_CALL_SITE),
+        0,
+      )
+      const indirectCalls = sources.reduce(
+        (total, source) => total + countMatches(source, HELPER_INDIRECT_CALL),
+        0,
+      )
+      const parsed =
+        sources.flatMap((source) => extractRouteCalls(source)).length +
+        sources.flatMap((source) => extractTemplateCalls(source)).length
+
+      expect(callSites).toBeGreaterThan(0)
+      expect(parsed + indirectCalls).toBeGreaterThanOrEqual(callSites)
+    })
   })
 })


### PR DESCRIPTION
## What

Replaces this app's route guard with the kernel now shared by the three apps. Only the `SURFACES` table stays app-specific — including its note that the cross-app probes in `app.mts` target com.melcloud's routes, not this app's.

Companion PRs: OlivierZal/com.melcloud#1497 and OlivierZal/com.heatzy#1051.

## Why

The guard lived in three copies with ~10 helpers triplicated, and the method check this app gained yesterday was a third hand-written variant of the same logic. Taking it from a shared kernel instead means the divergence never lands: byte-identical copies edited together is the idiom the family already uses for `callback-api.mts` and `dirty-gate.mts`.

Same coverage as yesterday's PR, same mutation result (turning the `/cooling/auto-adjustment` `homeyApiPut` into `homeyApiPost` fails the pair check), plus the two sweeps the kernel carries: template-built paths, and path-shaped templates written outside a call. Both are inert here today and become active the moment a call site stops writing its path literally.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (127 tests, coverage 100%)
- [x] `npm run homey:validate` passes at `publish` level