### PR TITLE
fix: sanitize the persisted settings the app reads back

### DIFF
--- a/api.mts
+++ b/api.mts
@@ -61,7 +61,7 @@ const api = {
     }
     return groupAdjustableDevices(
       app.melcloudDevices,
-      app.homey.settings.get('outdoorSources') ?? {},
+      app.outdoorSources,
       await app.refreshDeviceGroups(),
     )
   },

--- a/app.mts
+++ b/app.mts
@@ -8,6 +8,10 @@ import { fireAndForget } from './lib/fire-and-forget.mts'
 import { getErrorMessage } from './lib/get-error-message.mts'
 import { type Homey, App } from './lib/homey.mts'
 import { toDeviceGroups } from './lib/to-device-groups.mts'
+import { toListenerData } from './lib/to-listener-data.mts'
+import { toOutdoorSources } from './lib/to-outdoor-sources.mts'
+import { toThresholds } from './lib/to-thresholds.mts'
+import { toTimestampedLogs } from './lib/to-timestamped-logs.mts'
 import { CapabilityOutdoorSource } from './listeners/capability-source.mts'
 import { ListenerError } from './listeners/error.mts'
 import { MELCloudListener } from './listeners/melcloud.mts'
@@ -18,6 +22,7 @@ import {
   type Names,
   type OutdoorSources,
   type TemperatureListenerData,
+  type Thresholds,
   type TimestampedLog,
   DISABLED_SOURCE,
   MEASURE_TEMPERATURE,
@@ -66,8 +71,18 @@ export default class MELCloudExtensionApp extends App {
     }
   }
 
+  // Sanitized and fresh on every read: a corrupt entry reads as absent,
+  // and callers may mutate the result without touching the store.
+  public get outdoorSources(): OutdoorSources {
+    return toOutdoorSources(this.homey.settings.get('outdoorSources')) ?? {}
+  }
+
   public get temperatureSensors(): HomeyAPIV3Local.ManagerDevices.Device[] {
     return this.#temperatureSensors
+  }
+
+  public get thresholds(): Thresholds {
+    return toThresholds(this.homey.settings.get('thresholds')) ?? {}
   }
 
   #api!: HomeyAPIV3Local
@@ -116,11 +131,11 @@ export default class MELCloudExtensionApp extends App {
   // Starts or restarts automatic cooling adjustment. A device whose
   // source fails to validate is reported and skipped; the others keep
   // running.
-  public async autoAdjustCooling(
-    temperatureListenerData?: TemperatureListenerData,
-  ): Promise<void> {
+  public async autoAdjustCooling(payload?: unknown): Promise<void> {
     const { isEnabled, outdoorSources } =
-      temperatureListenerData ?? this.#getStoredListenerData()
+      payload === undefined
+        ? this.#getStoredListenerData()
+        : toListenerData(payload)
     await this.#destroyListeners()
     this.homey.settings.set('isEnabled', isEnabled)
     this.homey.settings.set('outdoorSources', outdoorSources)
@@ -247,7 +262,7 @@ export default class MELCloudExtensionApp extends App {
   #getStoredListenerData(): TemperatureListenerData {
     return {
       isEnabled: this.homey.settings.get('isEnabled') === true,
-      outdoorSources: this.homey.settings.get('outdoorSources') ?? {},
+      outdoorSources: this.outdoorSources,
     }
   }
 
@@ -336,7 +351,11 @@ export default class MELCloudExtensionApp extends App {
     if (typeof legacyPath !== 'string') {
       return
     }
-    if ((this.homey.settings.get('outdoorSources') ?? null) === null) {
+    // The one raw read: it needs "nothing stored" (never migrated)
+    // distinguished from "an empty map was stored", which the getter's
+    // `?? {}` would flatten. A garbage value now also reads as not yet
+    // migrated, which is the right call.
+    if (toOutdoorSources(this.homey.settings.get('outdoorSources')) === null) {
       this.homey.settings.set(
         'outdoorSources',
         Object.fromEntries(
@@ -348,7 +367,8 @@ export default class MELCloudExtensionApp extends App {
   }
 
   #persistLog(newLog: TimestampedLog): void {
-    const lastLogs = this.homey.settings.get('lastLogs') ?? []
+    const lastLogs =
+      toTimestampedLogs(this.homey.settings.get('lastLogs')) ?? []
     this.homey.settings.set(
       'lastLogs',
       [newLog, ...lastLogs].slice(0, MAX_LOGS),
@@ -366,9 +386,7 @@ export default class MELCloudExtensionApp extends App {
   // legacy default (null = Homey weather) and changes nothing;
   // afterwards newcomers go through #inheritedSource.
   #seedOutdoorSources(): void {
-    const stored: OutdoorSources = {
-      ...this.homey.settings.get('outdoorSources'),
-    }
+    const stored: OutdoorSources = this.outdoorSources
     const newcomers = this.#melcloudDevices.filter(
       ({ id }) => !Object.hasOwn(stored, id),
     )

--- a/lib/is-record.mts
+++ b/lib/is-record.mts
@@ -1,0 +1,7 @@
+// Narrows to an indexable shape before `Object.entries`, which would
+// otherwise resolve to its `[string, any][]` overload and drag `any`
+// through every caller.
+export const isRecord = (
+  payload: unknown,
+): payload is Record<string, unknown> =>
+  typeof payload === 'object' && payload !== null && !Array.isArray(payload)

--- a/lib/to-listener-data.mts
+++ b/lib/to-listener-data.mts
@@ -1,0 +1,18 @@
+import type { TemperatureListenerData } from '../types.mts'
+import { isRecord } from './is-record.mts'
+import { toOutdoorSources } from './to-outdoor-sources.mts'
+
+// Sanitizes the settings page's PUT body before it is persisted
+// verbatim. Sanitizing on read while the ingress stays open is half a
+// fix: an off-shape body would otherwise become the stored value every
+// reader then has to defend against.
+//
+// Unlike the read-side sanitizers this one cannot degrade to `null` —
+// the caller has to act on something — so it falls back to the safe
+// pair: adjustment off, no per-device source.
+export const toListenerData = (payload: unknown): TemperatureListenerData => ({
+  isEnabled: isRecord(payload) && payload.isEnabled === true,
+  outdoorSources: isRecord(payload)
+    ? (toOutdoorSources(payload.outdoorSources) ?? {})
+    : {},
+})

--- a/lib/to-outdoor-sources.mts
+++ b/lib/to-outdoor-sources.mts
@@ -1,0 +1,23 @@
+import type { OutdoorSources } from '../types.mts'
+import { isRecord } from './is-record.mts'
+
+const isEntry = (entry: [string, unknown]): entry is [string, string | null] =>
+  entry[1] === null || typeof entry[1] === 'string'
+
+// Sanitizes the persisted per-device sources. The container is
+// all-or-nothing and an entry is individual: a garbage map is not a
+// collection of user decisions, while a garbage entry sits beside nine
+// good ones and must not take them down. `null` is MEANINGFUL (the
+// Homey weather default) and is never dropped, and an absent key is
+// never materialised — `#seedOutdoorSources` tells the two apart with
+// `Object.hasOwn`. `null` is returned rather than `{}` so callers can
+// distinguish "nothing stored" from "an empty map was stored".
+//
+// The path itself is deliberately not validated: `#listenToDevice`
+// already reports a source it cannot resolve and skips that device
+// while the others keep running, so checking the shape here would turn
+// a visible, recoverable failure into a silent disappearance.
+export const toOutdoorSources = (payload: unknown): OutdoorSources | null =>
+  isRecord(payload)
+    ? Object.fromEntries(Object.entries(payload).filter(isEntry))
+    : null

--- a/lib/to-thresholds.mts
+++ b/lib/to-thresholds.mts
@@ -1,0 +1,21 @@
+import type { Thresholds } from '../types.mts'
+import { isRecord } from './is-record.mts'
+import { toTemperature } from './to-temperature.mts'
+
+const isEntry = (entry: [string, unknown]): entry is [string, number] =>
+  toTemperature(entry[1]) !== null
+
+// Sanitizes the persisted per-device comfort setpoints, on the same
+// contract as `toOutdoorSources`: the container is all-or-nothing, an
+// entry is individual, and `null` is returned rather than `{}` so
+// "nothing stored" stays distinguishable. Finiteness is delegated to
+// `toTemperature` so one doctrine covers every reading, stored or live.
+//
+// No range clamping: `#getTargetTemperature` already bounds the value
+// by the device's advertised ceiling, and a dropped entry reads as
+// absent — which the revert path refuses to act on rather than
+// substituting a number nobody chose.
+export const toThresholds = (payload: unknown): Thresholds | null =>
+  isRecord(payload)
+    ? Object.fromEntries(Object.entries(payload).filter(isEntry))
+    : null

--- a/lib/to-timestamped-logs.mts
+++ b/lib/to-timestamped-logs.mts
@@ -1,0 +1,24 @@
+import type { TimestampedLog } from '../types.mts'
+
+// `category` is optional, so absent-or-string is the check — requiring
+// it would drop every entry the app writes without one.
+const hasValidCategory = (entry: object): boolean =>
+  !('category' in entry) || typeof entry.category === 'string'
+
+const isTimestampedLog = (entry: unknown): entry is TimestampedLog =>
+  typeof entry === 'object' &&
+  entry !== null &&
+  'message' in entry &&
+  typeof entry.message === 'string' &&
+  'time' in entry &&
+  typeof entry.time === 'number' &&
+  Number.isFinite(entry.time) &&
+  hasValidCategory(entry)
+
+// Sanitizes the persisted UI log history. Same contract as the sibling
+// sanitizers, and not merely defensive: `#persistLog` spreads this
+// value into a new array, so a stored non-iterable would throw inside
+// the very call every listener uses to report — turning one bad
+// settings value into an app that dies on its first log line.
+export const toTimestampedLogs = (payload: unknown): TimestampedLog[] | null =>
+  Array.isArray(payload) ? payload.filter(isTimestampedLog) : null

--- a/listeners/melcloud.mts
+++ b/listeners/melcloud.mts
@@ -178,7 +178,7 @@ export class MELCloudListener {
   }
 
   #getThresholds(): Thresholds {
-    return this.#app.homey.settings.get('thresholds') ?? {}
+    return this.#app.thresholds
   }
 
   // The current target temperature seeds the user threshold; a manual

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -17,3 +17,11 @@ export const mock = <T>(overrides: Partial<Record<keyof T, unknown>> = {}): T =>
  * under a `default` key its declared type does not have.
  */
 export type InteropModule<TModule> = TModule & { default: TModule }
+
+// Feeds a deliberately off-shape value where the type forbids one, so a
+// sanitizer can be tested against what a hand-edited setting actually
+// looks like. Same helper as melcloud-api's.
+export function cast(value: unknown): never
+export function cast(value: unknown): unknown {
+  return value
+}

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type MELCloudExtensionApp from '../../app.mts'
 import type { HomeySettings, TemperatureListenerData } from '../../types.mts'
+import { toOutdoorSources } from '../../lib/to-outdoor-sources.mts'
 import { mock } from '../helpers.ts'
 import { createMockDevice } from '../mocks.ts'
 import api from '../../api.mts'
@@ -61,6 +62,9 @@ const createHomeyContext = ({
       },
       log: vi.fn<(...args: readonly unknown[]) => void>(),
       melcloudDevices,
+      // Projected through the real sanitizer, exactly as the app getter
+      // does, so an off-shape fixture exercises the degradation here.
+      outdoorSources: toOutdoorSources(settings.outdoorSources) ?? {},
       refreshDeviceGroups: vi
         .fn<MELCloudExtensionApp['refreshDeviceGroups']>()
         .mockResolvedValue(deviceGroups),

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as HomeyLib from '../../lib/homey.mts'
 import type { TimestampedLog } from '../../types.mts'
 import { changelog } from '../../files.mts'
-import { assertDefined } from '../helpers.ts'
+import { assertDefined, cast } from '../helpers.ts'
 import {
   type MockDevice,
   type MockHomey,
@@ -436,6 +436,120 @@ describe(MELCloudExtensionApp, () => {
     expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
       'classic-1': null,
     })
+  })
+
+  // An explicit null is the Homey-weather default, not an absent entry:
+  // dropping it would make #seedOutdoorSources re-seed the device as a
+  // newcomer. This is the Object.hasOwn regression guard.
+  it('should keep an explicit null source through sanitizing', async () => {
+    const { classicDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice], {
+      settings: {
+        hasSeededOutdoorSources: true,
+        outdoorSources: { 'classic-1': null },
+      },
+    })
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+    })
+  })
+
+  it('should read an off-shape outdoorSources setting as nothing stored', async () => {
+    const { classicDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice], {
+      settings: { outdoorSources: cast('garbage') },
+    })
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+    })
+  })
+
+  it('should still migrate the legacy source over an off-shape map', async () => {
+    const { classicDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice], {
+      settings: {
+        capabilityPath: 'classic-1:measure_temperature.outdoor',
+        outdoorSources: cast('garbage'),
+      },
+    })
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.capabilityPath).toBeUndefined()
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': 'classic-1:measure_temperature.outdoor',
+    })
+  })
+
+  it('should drop a corrupt source entry and re-seed the device as a newcomer', async () => {
+    const { classicDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice], {
+      settings: {
+        hasSeededOutdoorSources: true,
+        outdoorSources: cast({ 'classic-1': 42 }),
+      },
+    })
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': 'none',
+    })
+  })
+
+  // #persistLog spreads the stored value, so a non-iterable would throw
+  // inside the call every listener uses to report.
+  it('should drop an off-shape log history instead of crashing', async () => {
+    const { classicDevice } = createDevices()
+    const { app, mockHomey } = await createHarness([classicDevice], {
+      settings: { lastLogs: cast('nope') },
+    })
+
+    await advancePastInit()
+    app.pushToUI('cleanedAll')
+
+    // Unsanitized, the string would have been spread character by
+    // character into the history instead of being dropped.
+    expect(
+      mockHomey.settingsStore.lastLogs?.every(
+        (entry) => typeof entry === 'object',
+      ),
+    ).toBe(true)
+  })
+
+  it('should drop off-shape entries from the log history', async () => {
+    const { classicDevice } = createDevices()
+    const { app, mockHomey } = await createHarness([classicDevice], {
+      settings: {
+        lastLogs: cast([{ message: 'kept', time: 1 }, { message: 2 }]),
+      },
+    })
+
+    await advancePastInit()
+    app.pushToUI('cleanedAll')
+
+    expect(mockHomey.settingsStore.lastLogs).toContainEqual({
+      message: 'kept',
+      time: 1,
+    })
+    expect(mockHomey.settingsStore.lastLogs).not.toContainEqual({ message: 2 })
+  })
+
+  it('should read an off-shape listener body as disabled without sources', async () => {
+    const { classicDevice } = createDevices()
+    const { app, mockHomey } = await createHarness([classicDevice])
+
+    await advancePastInit()
+    await app.autoAdjustCooling('garbage')
+
+    expect(mockHomey.settingsStore.isEnabled).toBe(false)
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({})
   })
 
   it('should log instead of crashing when the debounced reload fails', async () => {

--- a/tests/unit/melcloud-listener.test.ts
+++ b/tests/unit/melcloud-listener.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type MELCloudExtensionApp from '../../app.mts'
 import type { OutdoorSource } from '../../listeners/outdoor-source.mts'
-import type { HomeySettings } from '../../types.mts'
+import type { HomeySettings, Thresholds } from '../../types.mts'
+import { toThresholds } from '../../lib/to-thresholds.mts'
 import { MELCloudListener } from '../../listeners/melcloud.mts'
 import { assertDefined, mock } from '../helpers.ts'
 import { type MockDevice, createMockDevice, names } from '../mocks.ts'
@@ -80,6 +81,11 @@ const createHarness = ({
     },
     names,
     pushToUI,
+    // A getter, not a snapshot: tests mutate settingsStore mid-run and
+    // the listener must see it, exactly as the real app getter does.
+    get thresholds(): Thresholds {
+      return toThresholds(settingsStore.thresholds) ?? {}
+    },
   })
   const source = mock<OutdoorSource>({
     attach,

--- a/tests/unit/to-listener-data.test.ts
+++ b/tests/unit/to-listener-data.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { toListenerData } from '../../lib/to-listener-data.mts'
+
+describe(toListenerData, () => {
+  it('should keep a well-shaped body', () => {
+    expect(
+      toListenerData({
+        isEnabled: true,
+        outdoorSources: { 'ac-1': 'none', 'ac-2': null },
+      }),
+    ).toStrictEqual({
+      isEnabled: true,
+      outdoorSources: { 'ac-1': 'none', 'ac-2': null },
+    })
+  })
+
+  it.each([
+    ['a string body', 'oops'],
+    ['a null body', null],
+    ['an array body', []],
+    ['an off-shape outdoorSources', { isEnabled: true, outdoorSources: 'x' }],
+    ['a missing outdoorSources', { isEnabled: true }],
+  ])('should fall back to no source for %s', (_description, payload) => {
+    expect(toListenerData(payload).outdoorSources).toStrictEqual({})
+  })
+
+  it.each([
+    ['a non-boolean isEnabled', { isEnabled: 'true' }],
+    ['a missing isEnabled', { outdoorSources: {} }],
+    ['a null body', null],
+  ])('should read %s as disabled', (_description, payload) => {
+    expect(toListenerData(payload).isEnabled).toBe(false)
+  })
+})

--- a/tests/unit/to-outdoor-sources.test.ts
+++ b/tests/unit/to-outdoor-sources.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { toOutdoorSources } from '../../lib/to-outdoor-sources.mts'
+
+describe(toOutdoorSources, () => {
+  it('should keep every well-shaped entry, null included', () => {
+    expect(
+      toOutdoorSources({
+        'ac-1': 'sensor-1:measure_temperature',
+        'ac-2': 'none',
+        'ac-3': null,
+      }),
+    ).toStrictEqual({
+      'ac-1': 'sensor-1:measure_temperature',
+      'ac-2': 'none',
+      'ac-3': null,
+    })
+  })
+
+  it('should accept an empty map as an empty map, not as nothing stored', () => {
+    expect(toOutdoorSources({})).toStrictEqual({})
+  })
+
+  it('should return a fresh object the caller may mutate', () => {
+    const payload = { 'ac-1': null }
+    const sanitized = toOutdoorSources(payload)
+
+    expect(sanitized).not.toBe(payload)
+  })
+
+  it.each([
+    ['a number', 21],
+    ['a boolean', true],
+    ['an object', { nested: true }],
+    ['an array', ['sensor-1:measure_temperature']],
+    ['undefined', undefined],
+  ])(
+    'should drop an entry whose value is %s, keeping its neighbours',
+    (_description, value) => {
+      expect(
+        toOutdoorSources({ 'ac-1': 'none', 'ac-2': value, 'ac-3': null }),
+      ).toStrictEqual({ 'ac-1': 'none', 'ac-3': null })
+    },
+  )
+
+  it.each([
+    ['a string', 'garbage'],
+    ['a number', 42],
+    ['an array', []],
+    ['null', null],
+    ['undefined', undefined],
+  ])('should read %s as nothing stored', (_description, payload) => {
+    expect(toOutdoorSources(payload)).toBeNull()
+  })
+})

--- a/tests/unit/to-thresholds.test.ts
+++ b/tests/unit/to-thresholds.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { toThresholds } from '../../lib/to-thresholds.mts'
+
+describe(toThresholds, () => {
+  it('should keep every finite reading, zero and negatives included', () => {
+    expect(
+      toThresholds({ 'ac-1': 23, 'ac-2': 0, 'ac-3': -5, 'ac-4': 21.5 }),
+    ).toStrictEqual({ 'ac-1': 23, 'ac-2': 0, 'ac-3': -5, 'ac-4': 21.5 })
+  })
+
+  it('should accept an empty map as an empty map, not as nothing stored', () => {
+    expect(toThresholds({})).toStrictEqual({})
+  })
+
+  it('should return a fresh object the caller may mutate', () => {
+    const payload = { 'ac-1': 23 }
+    const sanitized = toThresholds(payload)
+
+    expect(sanitized).not.toBe(payload)
+  })
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['a numeric string', '23'],
+    ['null', null],
+    ['undefined', undefined],
+    ['a boolean', true],
+  ])(
+    'should drop an entry whose value is %s, keeping its neighbours',
+    (_description, value) => {
+      expect(
+        toThresholds({ 'ac-1': 23, 'ac-2': value, 'ac-3': 19 }),
+      ).toStrictEqual({ 'ac-1': 23, 'ac-3': 19 })
+    },
+  )
+
+  it.each([
+    ['a string', 'garbage'],
+    ['a number', 42],
+    ['an array', []],
+    ['null', null],
+    ['undefined', undefined],
+  ])('should read %s as nothing stored', (_description, payload) => {
+    expect(toThresholds(payload)).toBeNull()
+  })
+})

--- a/tests/unit/to-timestamped-logs.test.ts
+++ b/tests/unit/to-timestamped-logs.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { toTimestampedLogs } from '../../lib/to-timestamped-logs.mts'
+
+describe(toTimestampedLogs, () => {
+  it('should keep entries with and without a category', () => {
+    const payload = [
+      { category: 'error', message: 'boom', time: 2 },
+      { message: 'plain', time: 1 },
+    ]
+
+    expect(toTimestampedLogs(payload)).toStrictEqual(payload)
+  })
+
+  it('should accept an empty history as an empty history', () => {
+    expect(toTimestampedLogs([])).toStrictEqual([])
+  })
+
+  it.each([
+    ['a non-object', 'oops'],
+    ['null', null],
+    ['a missing message', { time: 1 }],
+    ['a non-string message', { message: 2, time: 1 }],
+    ['a missing time', { message: 'x' }],
+    ['a non-number time', { message: 'x', time: 'now' }],
+    ['a non-finite time', { message: 'x', time: Number.NaN }],
+    ['a non-string category', { category: 1, message: 'x', time: 1 }],
+  ])('should drop %s, keeping its neighbours', (_description, entry) => {
+    const kept = { message: 'kept', time: 3 }
+
+    expect(toTimestampedLogs([entry, kept])).toStrictEqual([kept])
+  })
+
+  it.each([
+    ['a string', 'garbage'],
+    ['an object', { message: 'x', time: 1 }],
+    ['null', null],
+    ['undefined', undefined],
+  ])('should read %s as nothing stored', (_description, payload) => {
+    expect(toTimestampedLogs(payload)).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Puts the three structured settings keys behind sanitizers, on the `lib/to-*.mts` pattern the app already uses for external input, and closes the write ingress too.

## Why

`outdoorSources`, `thresholds` and `lastLogs` were read with a bare `?? {}` / `?? []` and nothing else. Homey app settings are visible **and editable** in developer tools, so that is untrusted input — and the app already sanitizes its *external* inputs (`lib/to-device-groups.mts` for the inter-app payload, `lib/to-temperature.mts` for a sensor reading) while trusting its own stored state.

**`lastLogs` was a live crash vector, not a hypothetical.** `#persistLog` does `[newLog, ...lastLogs]`: a hand-edited string is spread character by character into the history, and a non-iterable throws — inside `pushToUI`, the call every listener uses to report. One bad settings value and the app dies on its first log line after boot.

## The contract

Copied from `toDeviceGroups`: **the container is all-or-nothing, an entry is individual.** A garbage map is not a collection of user decisions; a garbage entry sits beside nine good ones and must not take them down.

Two invariants preserved on purpose, both load-bearing:

- **`null` is meaningful** (the Homey-weather default) and is never dropped, and no sanitizer ever materialises an absent key — `#seedOutdoorSources` tells "never written" from "explicitly null" with `Object.hasOwn`. A regression test pins it.
- **The map sanitizers return `null`, not `{}`** — `#migrateLegacySource` needs "nothing stored" distinguished from "an empty map was stored". It is the one deliberately raw read, and a garbage value now also reads as "not yet migrated", which is the right call.

Deliberately **not** validated: whether a source string is well-formed. `#listenToDevice` already reports a source it cannot resolve and skips that device while the others keep running — checking the shape here would turn a visible, recoverable failure into a silent disappearance.

## Also

`lib/to-listener-data.mts` sanitizes the settings-page PUT body, which `autoAdjustCooling` persisted verbatim. Sanitizing on read while the ingress stays open is half a fix.

Incidental: the app getters return a fresh object every read, which removes the aliasing in `#setThreshold` (it mutated the object `settings.get` handed back) and the defensive spread in `#seedOutdoorSources`.

## Behaviour change to note

An entry whose value is explicitly `undefined` is now dropped, so that device re-seeds as a newcomer — `Object.hasOwn({k: undefined}, 'k')` is `true`, so today it reads as "written, Homey weather".

## Verification

Mutation-tested rather than assumed: removing the `lastLogs` sanitizer fails both of its regression tests.

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (184 tests, coverage 100% on statements, branches, functions and lines)
- [x] `npm run homey:validate` passes at `publish` level

No user-visible behaviour change beyond degrading corrupt input, so no changelog entry — the revert-refusal work and the pruning follow in their own PRs.