### PR TITLE
fix: refuse to write a setpoint nobody chose, instead of sending 0 °C

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -421,5 +421,20 @@
     "pl": "Aplikacja nie pokazuje już błędu na Homey Pro (2019), gdy lista urządzeń jest niedostępna. Jeśli strona ustawień była otwarta przed tą aktualizacją, zamknij ją i otwórz ponownie — stara strona może nie zapisać zmian.",
     "ru": "Приложение больше не показывает ошибку на Homey Pro (2019), когда список устройств недоступен. Если страница настроек была открыта до этого обновления, закройте и откройте её заново — старая страница может не сохранить изменения.",
     "sv": "Appen visar inte längre ett fel på Homey Pro (2019) när en enhetslista inte är tillgänglig. Om inställningssidan var öppen före den här uppdateringen, stäng och öppna den igen — en gammal sida kan misslyckas när du sparar."
+  },
+  "25.1.0": {
+    "ar": "لم يعد التطبيق يرسل 0 °م عندما لا تكون درجة الحرارة المرجعية محفوظة: لا يُرسل أي أمر ويظهر سبب ذلك في السجل.",
+    "da": "Appen sender ikke længere 0 °C, når din gemte temperatur mangler: den sender ingenting og skriver årsagen i loggen.",
+    "de": "Die App sendet keine 0 °C mehr, wenn deine gespeicherte Temperatur fehlt: sie sendet nichts und schreibt den Grund ins Protokoll.",
+    "en": "The app no longer sends 0 °C when your stored temperature is missing: it sends nothing and says why in the log.",
+    "es": "La app ya no envía 0 °C cuando falta tu temperatura guardada: no envía nada y explica el motivo en el registro.",
+    "fr": "L'app n'envoie plus 0 °C lorsque votre température enregistrée est absente : elle n'envoie rien et en indique la raison dans le journal.",
+    "it": "L'app non invia più 0 °C quando la tua temperatura salvata manca: non invia nulla e ne spiega il motivo nel registro.",
+    "ko": "저장된 온도가 없을 때 앱이 더 이상 0 °C를 보내지 않습니다. 아무것도 보내지 않고 그 이유를 로그에 남깁니다.",
+    "nl": "De app stuurt niet langer 0 °C wanneer je opgeslagen temperatuur ontbreekt: er wordt niets verstuurd en de reden staat in het logboek.",
+    "no": "Appen sender ikke lenger 0 °C når den lagrede temperaturen din mangler: den sender ingenting og skriver årsaken i loggen.",
+    "pl": "Aplikacja nie wysyła już 0 °C, gdy brakuje zapisanej temperatury: nic nie wysyła i podaje powód w dzienniku.",
+    "ru": "Приложение больше не отправляет 0 °C, когда сохранённая температура отсутствует: оно ничего не отправляет и указывает причину в журнале.",
+    "sv": "Appen skickar inte längre 0 °C när din sparade temperatur saknas: den skickar ingenting och anger orsaken i loggen."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -194,5 +194,5 @@
       "värmepump"
     ]
   },
-  "version": "25.0.0"
+  "version": "25.1.0"
 }

--- a/app.json
+++ b/app.json
@@ -195,5 +195,5 @@
       "värmepump"
     ]
   },
-  "version": "25.0.0"
+  "version": "25.1.0"
 }

--- a/app.mts
+++ b/app.mts
@@ -72,9 +72,16 @@ export default class MELCloudExtensionApp extends App {
   }
 
   // Sanitized and fresh on every read: a corrupt entry reads as absent,
-  // and callers may mutate the result without touching the store.
+  // and callers may mutate the result without touching the store. The
+  // accessor pair is the only door to each key, so the key name and its
+  // sanitizer sit together instead of being restated at every site —
+  // and a caller cannot write past the contract its reader assumes.
   public get outdoorSources(): OutdoorSources {
     return toOutdoorSources(this.homey.settings.get('outdoorSources')) ?? {}
+  }
+
+  public set outdoorSources(value: OutdoorSources) {
+    this.homey.settings.set('outdoorSources', value)
   }
 
   public get temperatureSensors(): HomeyAPIV3Local.ManagerDevices.Device[] {
@@ -83,6 +90,10 @@ export default class MELCloudExtensionApp extends App {
 
   public get thresholds(): Thresholds {
     return toThresholds(this.homey.settings.get('thresholds')) ?? {}
+  }
+
+  public set thresholds(value: Thresholds) {
+    this.homey.settings.set('thresholds', value)
   }
 
   #api!: HomeyAPIV3Local
@@ -138,7 +149,7 @@ export default class MELCloudExtensionApp extends App {
         : toListenerData(payload)
     await this.#destroyListeners()
     this.homey.settings.set('isEnabled', isEnabled)
-    this.homey.settings.set('outdoorSources', outdoorSources)
+    this.outdoorSources = outdoorSources
     if (!isEnabled) {
       return
     }
@@ -356,11 +367,8 @@ export default class MELCloudExtensionApp extends App {
     // `?? {}` would flatten. A garbage value now also reads as not yet
     // migrated, which is the right call.
     if (toOutdoorSources(this.homey.settings.get('outdoorSources')) === null) {
-      this.homey.settings.set(
-        'outdoorSources',
-        Object.fromEntries(
-          this.#melcloudDevices.map(({ id }) => [id, legacyPath]),
-        ),
+      this.outdoorSources = Object.fromEntries(
+        this.#melcloudDevices.map(({ id }) => [id, legacyPath]),
       )
     }
     this.homey.settings.unset('capabilityPath')
@@ -396,7 +404,7 @@ export default class MELCloudExtensionApp extends App {
       stored[id] = isLegacySeed ? null : this.#inheritedSource(id, stored)
     }
     if (newcomers.length > 0) {
-      this.homey.settings.set('outdoorSources', stored)
+      this.outdoorSources = stored
     }
     if (isLegacySeed) {
       this.homey.settings.set('hasSeededOutdoorSources', true)

--- a/listeners/melcloud.mts
+++ b/listeners/melcloud.mts
@@ -11,7 +11,6 @@ const COOL = 'cool'
 const TARGET_TEMPERATURE = 'target_temperature'
 const THERMOSTAT_MODE = 'thermostat_mode'
 
-const DEFAULT_TEMPERATURE = 0
 // Minimum gap between outdoor temperature and target cooling temperature
 const GAP_TEMPERATURE = 8
 
@@ -121,6 +120,10 @@ export class MELCloudListener {
       return
     }
     const value = this.#getTargetTemperature()
+    if (value === null) {
+      this.#app.pushToUI('error.noThreshold', { name: this.#device.name })
+      return
+    }
     await this.#targetTemperatureListener.setValue(value)
     this.#app.pushToUI('calculated', {
       name: this.#device.name,
@@ -162,19 +165,30 @@ export class MELCloudListener {
   // - At least the user-defined threshold (minimum comfort temperature)
   // - At least outdoor temperature minus GAP_TEMPERATURE (efficiency floor)
   // - At most the device's advertised setpoint ceiling
-  #getTargetTemperature(): number {
-    return Math.min(
-      Math.max(
-        this.#getThreshold(),
-        ceilToSetpointStep(this.#source.value ?? DEFAULT_TEMPERATURE) -
-          GAP_TEMPERATURE,
-      ),
-      this.#getMaxTemperature(),
-    )
+  //
+  // Each floor is a term only when it is known: no outdoor reading means
+  // no efficiency floor, not a floor computed from a stand-in number.
+  #getTargetTemperature(): number | null {
+    const outdoor = this.#source.value
+    const floors = [
+      this.#getThreshold(),
+      outdoor === null ? null : ceilToSetpointStep(outdoor) - GAP_TEMPERATURE,
+    ].filter((floor): floor is number => floor !== null)
+    // Neither a stored setpoint nor a reading: nothing constrains the
+    // target, so there is no target to compute. Math.max of nothing is
+    // -Infinity, which would be a worse invention than the 0 this
+    // replaces.
+    return floors.length === 0
+      ? null
+      : Math.min(Math.max(...floors), this.#getMaxTemperature())
   }
 
-  #getThreshold(): number {
-    return this.#getThresholds()[this.#device.id] ?? DEFAULT_TEMPERATURE
+  // `null` when the user has no stored comfort setpoint for this device:
+  // absent, never a stand-in value. Callers decide what to do without
+  // one — the revert path refuses to write rather than inventing a
+  // setpoint nobody chose.
+  #getThreshold(): number | null {
+    return this.#getThresholds()[this.#device.id] ?? null
   }
 
   #getThresholds(): Thresholds {
@@ -216,9 +230,18 @@ export class MELCloudListener {
 
   // Restores the target temperature to the user's threshold when
   // auto-adjustment stops (e.g. device leaves cooling mode).
+  //
+  // Without a stored threshold there is nothing to restore, so nothing
+  // is written: leaving the unit where it is beats commanding a setpoint
+  // the user never chose. This path used to send the 0 °C that stood in
+  // for "absent".
   async #revertTemperature(): Promise<void> {
+    const value = this.#getThreshold()
+    if (value === null) {
+      this.#app.pushToUI('error.noThreshold', { name: this.#device.name })
+      return
+    }
     try {
-      const value = this.#getThreshold()
       await this.#device.setCapabilityValue({
         capabilityId: TARGET_TEMPERATURE,
         value,
@@ -237,9 +260,7 @@ export class MELCloudListener {
 
   async #setThreshold(value: number): Promise<void> {
     const { id, name } = this.#device
-    const thresholds = this.#getThresholds()
-    thresholds[id] = value
-    this.#app.homey.settings.set('thresholds', thresholds)
+    this.#app.thresholds = { ...this.#app.thresholds, [id]: value }
     this.#app.pushToUI('saved', { name, value: formatTemperature(value) })
     await this.setTargetTemperature()
   }

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -6,6 +6,7 @@
     "created": "إنشاء مستمع لـ __capability__ في __name__",
     "listened": "الاستماع إلى __capability__ في __name__: __value__",
     "notFound": "__type__ `__idOrName__` غير موجود",
+    "noThreshold": "لا توجد درجة حرارة مرجعية محفوظة لـ __name__: لم يتم إرسال أي أمر",
     "reverted": "استعادة درجة حرارة __name__: __value__",
     "saved": "حفظ درجة حرارة __name__: __value__"
   },

--- a/locales/da.json
+++ b/locales/da.json
@@ -6,6 +6,7 @@
     "created": "Opretter en lytter for __capability__ af __name__",
     "listened": "Lytter til __capability__ af __name__: __value__",
     "notFound": "__type__ `__idOrName__` ikke fundet",
+    "noThreshold": "Ingen gemt måltemperatur for __name__: der blev ikke sendt nogen kommando",
     "reverted": "Gendanner temperaturen for __name__: __value__",
     "saved": "Gemmer temperaturen for __name__: __value__"
   },

--- a/locales/de.json
+++ b/locales/de.json
@@ -6,6 +6,7 @@
     "created": "Listener für __capability__ von __name__ wird erstellt",
     "listened": "__capability__ von __name__ wird überwacht: __value__",
     "notFound": "__type__ `__idOrName__` nicht gefunden",
+    "noThreshold": "Keine gespeicherte Solltemperatur für __name__: es wurde kein Befehl gesendet",
     "reverted": "Temperatur von __name__ wird zurückgesetzt: __value__",
     "saved": "Temperatur von __name__ wird gespeichert: __value__"
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -6,6 +6,7 @@
     "created": "Creating a listener for __capability__ of __name__",
     "listened": "Listening to __capability__ of __name__: __value__",
     "notFound": "__type__ `__idOrName__` not found",
+    "noThreshold": "No stored temperature for __name__: nothing was sent to the unit",
     "reverted": "Reverting the temperature of __name__: __value__",
     "saved": "Saving the temperature of __name__: __value__"
   },

--- a/locales/es.json
+++ b/locales/es.json
@@ -6,6 +6,7 @@
     "created": "Creación de un oyente para __capability__ de __name__",
     "listened": "Escucha de __capability__ de __name__: __value__",
     "notFound": "No se puede encontrar __type__ `__idOrName__`",
+    "noThreshold": "No hay temperatura guardada para __name__: no se envió ninguna orden",
     "reverted": "Restablecimiento de la temperatura de __name__: __value__",
     "saved": "Guardado de la temperatura de __name__: __value__"
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -6,6 +6,7 @@
     "created": "Création d'un écouteur pour __capability__ de __name__",
     "listened": "Écoute de __capability__ de __name__ : __value__",
     "notFound": "__type__ `__idOrName__` introuvable",
+    "noThreshold": "Aucune température enregistrée pour __name__ : aucune commande envoyée",
     "reverted": "Rétablissement de la température de __name__ : __value__",
     "saved": "Enregistrement de la température de __name__ : __value__"
   },

--- a/locales/it.json
+++ b/locales/it.json
@@ -6,6 +6,7 @@
     "created": "Creazione di un listener per __capability__ di __name__",
     "listened": "In ascolto di __capability__ di __name__: __value__",
     "notFound": "__type__ `__idOrName__` non trovato",
+    "noThreshold": "Nessuna temperatura salvata per __name__: nessun comando inviato",
     "reverted": "Ripristino della temperatura di __name__: __value__",
     "saved": "Salvataggio della temperatura di __name__: __value__"
   },

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -6,6 +6,7 @@
     "created": "__name__의 __capability__ 리스너 생성 중",
     "listened": "__name__의 __capability__ 수신 중: __value__",
     "notFound": "__type__ `__idOrName__`을(를) 찾을 수 없습니다",
+    "noThreshold": "__name__에 저장된 온도가 없습니다: 명령을 보내지 않았습니다",
     "reverted": "__name__의 온도 복원 중: __value__",
     "saved": "__name__의 온도 저장 중: __value__"
   },

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -6,6 +6,7 @@
     "created": "Aanmaken van een luisteraar voor __capability__ van __name__",
     "listened": "Luisteren naar __capability__ van __name__: __value__",
     "notFound": "__type__ `__idOrName__` niet gevonden",
+    "noThreshold": "Geen opgeslagen temperatuur voor __name__: er is niets verstuurd",
     "reverted": "Herstellen van de temperatuur van __name__: __value__",
     "saved": "Opslaan van de temperatuur van __name__: __value__"
   },

--- a/locales/no.json
+++ b/locales/no.json
@@ -6,6 +6,7 @@
     "created": "Oppretter en lytter for __capability__ av __name__",
     "listened": "Lytter til __capability__ av __name__: __value__",
     "notFound": "__type__ `__idOrName__` ikke funnet",
+    "noThreshold": "Ingen lagret temperatur for __name__: ingen kommando ble sendt",
     "reverted": "Gjenoppretter temperaturen til __name__: __value__",
     "saved": "Lagrer temperaturen til __name__: __value__"
   },

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -6,6 +6,7 @@
     "created": "Tworzenie nasłuchu dla __capability__ urządzenia __name__",
     "listened": "Nasłuchiwanie __capability__ urządzenia __name__: __value__",
     "notFound": "Nie znaleziono: __type__ `__idOrName__`",
+    "noThreshold": "Brak zapisanej temperatury dla __name__: nie wysłano żadnego polecenia",
     "reverted": "Przywracanie temperatury __name__: __value__",
     "saved": "Zapisywanie temperatury __name__: __value__"
   },

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -6,6 +6,7 @@
     "created": "Создание слушателя __capability__ у __name__",
     "listened": "Отслеживание __capability__ у __name__: __value__",
     "notFound": "Не найдено: __type__ `__idOrName__`",
+    "noThreshold": "Нет сохранённой температуры для __name__: команда не отправлена",
     "reverted": "Восстановление температуры __name__: __value__",
     "saved": "Сохранение температуры __name__: __value__"
   },

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -6,6 +6,7 @@
     "created": "Skapar en lyssnare för __capability__ av __name__",
     "listened": "Lyssnar på __capability__ av __name__: __value__",
     "notFound": "__type__ `__idOrName__` hittades inte",
+    "noThreshold": "Ingen sparad temperatur för __name__: inget kommando skickades",
     "reverted": "Återställer temperaturen för __name__: __value__",
     "saved": "Sparar temperaturen för __name__: __value__"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.0.0",
+  "version": "25.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "25.0.0",
+      "version": "25.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.0.0",
+  "version": "25.1.0",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/tests/unit/melcloud-listener.test.ts
+++ b/tests/unit/melcloud-listener.test.ts
@@ -81,10 +81,14 @@ const createHarness = ({
     },
     names,
     pushToUI,
-    // A getter, not a snapshot: tests mutate settingsStore mid-run and
-    // the listener must see it, exactly as the real app getter does.
+    // The accessor PAIR, not a snapshot: tests mutate settingsStore
+    // mid-run and the listener must see it, and it writes back through
+    // the setter — exactly as the real app does.
     get thresholds(): Thresholds {
       return toThresholds(settingsStore.thresholds) ?? {}
+    },
+    set thresholds(value: Thresholds) {
+      Object.assign(settingsStore, { thresholds: value })
     },
   })
   const source = mock<OutdoorSource>({
@@ -265,18 +269,54 @@ describe(MELCloudListener, () => {
     expect(harness.attach).toHaveBeenCalledTimes(1)
   })
 
-  it('should revert to the default temperature when the stored threshold disappeared', async () => {
+  // It used to send 0 °C here — the stand-in value for "absent" reaching
+  // the unit as a real command.
+  it('should write nothing when the stored threshold disappeared', async () => {
     const harness = createHarness()
     await harness.listener.listenToThermostatMode()
     Object.assign(harness.settingsStore, { thresholds: {} })
+    harness.mockDevice.setCapabilityValue.mockClear()
 
     await getInstance(harness, 'thermostat_mode').listener('heat')
     await settleListeners()
 
-    expect(harness.mockDevice.setCapabilityValue).toHaveBeenCalledWith({
-      capabilityId: 'target_temperature',
-      value: 0,
+    expect(harness.mockDevice.setCapabilityValue).not.toHaveBeenCalled()
+    expect(harness.pushToUI).toHaveBeenCalledWith('error.noThreshold', {
+      name: 'Living room',
     })
+  })
+
+  // Nothing constrains the target: no stored setpoint and no reading.
+  // Math.max of no floor is -Infinity, so refusing is the only honest
+  // answer — this is the branch the old 0 °C stand-in hid.
+  it('should write nothing when neither a threshold nor a reading is known', async () => {
+    const harness = createHarness({ outdoorTemperature: null })
+    await harness.listener.listenToThermostatMode()
+    // Attaching seeds the threshold from the device's current setpoint,
+    // so both the store and that first write are cleared first.
+    Object.assign(harness.settingsStore, { thresholds: {} })
+    const instance = getInstance(harness, 'target_temperature')
+    instance.setValue.mockClear()
+    harness.pushToUI.mockClear()
+
+    await harness.listener.setTargetTemperature()
+
+    expect(instance.setValue).not.toHaveBeenCalled()
+    expect(harness.pushToUI).toHaveBeenCalledWith('error.noThreshold', {
+      name: 'Living room',
+    })
+  })
+
+  it('should ignore a corrupt stored threshold like an absent one', async () => {
+    const harness = createHarness()
+    await harness.listener.listenToThermostatMode()
+    Object.assign(harness.settingsStore, { thresholds: { 'ac-1': 'warm' } })
+    harness.mockDevice.setCapabilityValue.mockClear()
+
+    await getInstance(harness, 'thermostat_mode').listener('heat')
+    await settleListeners()
+
+    expect(harness.mockDevice.setCapabilityValue).not.toHaveBeenCalled()
   })
 
   it('should revert the temperature and release the outdoor listener when leaving cool', async () => {


### PR DESCRIPTION
## What

`DEFAULT_TEMPERATURE = 0` is gone. Where the value it stood in for is unknown, the app now writes nothing and says why.

## Why

The constant covered **two different absences** with one magic number, and one of them produced a real command:

- **`#revertTemperature`** wrote `#getThreshold()` straight into `target_temperature`. A missing entry meant **0 °C sent to the air conditioner** — the value that stood in for "absent" arriving at the unit as a genuine setpoint.
- **`#getTargetTemperature`** injected `0` for a missing outdoor reading; `0 - GAP` = −8 was absorbed by the `Math.max`, so it worked by accident. With the threshold *also* missing, both terms were 0 and the computed target was 0 °C.

Logging and carrying on — the obvious reflex — is the weakest of the three available answers here: the line gets written **and** the wrong order still goes out. It gives the impression the case was handled.

## What it does now

- **No stored threshold ⇒ nothing is written.** Reverting means restoring what the user asked for; with nothing stored there is nothing to restore, and leaving the unit where it is beats commanding a setpoint nobody chose. A new `log.noThreshold` message says so in the settings log, in all 13 locales.
- **No outdoor reading ⇒ no efficiency floor**, rather than a floor computed from a stand-in. A floor is a term only when it is known. `lib/to-temperature.mts` already models that absence as `null` upstream; the old line threw the information away.
- **Neither known ⇒ no target at all.** `Math.max` of no floor is `-Infinity`, which would be a worse invention than the 0 this replaces, so that path refuses too. That branch is now covered by a test — the old stand-in had hidden it entirely.

`DEFAULT_TEMPERATURE` disappearing is the tell that it was never a default, just a placeholder.

## Risk

Low: the normal path always seeds the threshold on attach (`#setThreshold` at the end of `#listenToTargetTemperature`), so the refusal is genuinely exceptional rather than a common no-op that would leave users without a revert.

The old test that pinned `value: 0` is rewritten to assert the refusal, with a comment recording what it used to do.

## Checklist

- [x] `.homeychangelog.json` updated under 25.1.0, 13 locales
- [x] `version` bumped in `.homeycompose/app.json`, aligned in `package.json`
- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm test` passes (186 tests, coverage 100% on statements, branches, functions and lines)
- [x] `npm run homey:validate` passes at `publish` level