### PR TITLE
fix: join the building grouping on the MELCloud id, not the Homey one

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -6,6 +6,7 @@ import type { OutdoorSource } from './listeners/outdoor-source.mts'
 import { changelog } from './files.mts'
 import { fireAndForget } from './lib/fire-and-forget.mts'
 import { getErrorMessage } from './lib/get-error-message.mts'
+import { toJoinKey } from './lib/group-devices.mts'
 import { type Homey, App } from './lib/homey.mts'
 import { toDeviceGroups } from './lib/to-device-groups.mts'
 import { toListenerData } from './lib/to-listener-data.mts'
@@ -247,6 +248,17 @@ export default class MELCloudExtensionApp extends App {
     }
   }
 
+  // Bridges the two id spaces: the building payload speaks MELCloud
+  // ids, every settings map is keyed by Homey id.
+  #getHomeyIdByMelcloudId(): Map<string, string> {
+    return new Map(
+      this.#melcloudDevices.flatMap((device) => {
+        const melcloudId = toJoinKey(device.data.id)
+        return melcloudId === null ? [] : [[melcloudId, device.id] as const]
+      }),
+    )
+  }
+
   async #getSource(sourcePath: string | null): Promise<OutdoorSource> {
     const key = sourcePath ?? WEATHER_SOURCE_KEY
     const existing = this.#sources.get(key)
@@ -280,13 +292,32 @@ export default class MELCloudExtensionApp extends App {
   // Newcomers inherit their building's outdoor source when the
   // siblings agree; a new building (or a mixed/ungrouped one) starts
   // disabled so no device gets auto-adjusted without an opt-in.
-  #inheritedSource(deviceId: string, stored: OutdoorSources): string | null {
-    const group = this.#deviceGroups?.find(({ deviceIds }) =>
-      deviceIds.includes(deviceId),
-    )
+  //
+  // Two id spaces meet here and must not be confused: the settings map
+  // is keyed by HOMEY device id, while the building payload lists
+  // MELCLOUD ids. Each device carries its MELCloud id in `data.id` —
+  // the same join `groupAdjustableDevices` uses — so comparing the two
+  // spaces directly never matched and every newcomer silently fell
+  // through to DISABLED_SOURCE.
+  #inheritedSource(
+    device: HomeyAPIV3Local.ManagerDevices.Device,
+    stored: OutdoorSources,
+  ): string | null {
+    const melcloudId = toJoinKey(device.data.id)
+    const group =
+      melcloudId === null
+        ? undefined
+        : this.#deviceGroups?.find(({ deviceIds }) =>
+            deviceIds.includes(melcloudId),
+          )
+    const homeyIdByMelcloudId = this.#getHomeyIdByMelcloudId()
     const siblingSources = new Set(
       (group?.deviceIds ?? [])
-        .filter((id) => id !== deviceId && Object.hasOwn(stored, id))
+        .filter((id) => id !== melcloudId)
+        .map((id) => homeyIdByMelcloudId.get(id))
+        .filter(
+          (id): id is string => id !== undefined && Object.hasOwn(stored, id),
+        )
         .map((id) => stored[id] ?? null),
     )
     if (siblingSources.size !== 1) {
@@ -400,8 +431,10 @@ export default class MELCloudExtensionApp extends App {
     )
     const isLegacySeed =
       this.homey.settings.get('hasSeededOutdoorSources') !== true
-    for (const { id } of newcomers) {
-      stored[id] = isLegacySeed ? null : this.#inheritedSource(id, stored)
+    for (const device of newcomers) {
+      stored[device.id] = isLegacySeed
+        ? null
+        : this.#inheritedSource(device, stored)
     }
     if (newcomers.length > 0) {
       this.outdoorSources = stored

--- a/lib/group-devices.mts
+++ b/lib/group-devices.mts
@@ -20,7 +20,7 @@ const SORT_BEFORE = -1
 
 // The homey-api device data is app-defined: only the id shapes the
 // MELCloud apps actually write can join with the building payload
-const toJoinKey = (id: unknown): string | null =>
+export const toJoinKey = (id: unknown): string | null =>
   typeof id === 'string' || typeof id === 'number' ? String(id) : null
 
 const byName = <T extends { readonly name: string }>(

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -60,6 +60,7 @@ const createDevices = (): {
     ],
     driverId: 'homey:app:com.mecloud:melcloud',
     id: 'classic-1',
+    melcloudId: '1000',
     name: 'Living room',
     values: {
       'measure_temperature.outdoor': 30,
@@ -75,6 +76,7 @@ const createDevices = (): {
     ],
     driverId: 'homey:app:com.mecloud:home-melcloud',
     id: 'home-1',
+    melcloudId: 'uuid-home-1',
     name: 'Bedroom',
     values: { target_temperature: 21, thermostat_mode: 'heat' },
   }),
@@ -128,7 +130,7 @@ describe(MELCloudExtensionApp, () => {
 
   it('should expose the building grouping fetched from com.melcloud', async () => {
     const { classicDevice } = createDevices()
-    const groups = [{ deviceIds: ['classic-1'], name: 'Domicile' }]
+    const groups = [{ deviceIds: ['1000'], name: 'Domicile' }]
     const { app, mockHomey } = await createHarness([classicDevice])
     mockHomey.apiAppGet.mockReturnValue(groups)
 
@@ -168,8 +170,8 @@ describe(MELCloudExtensionApp, () => {
       },
     })
     mockHomey.apiAppGet.mockReturnValue([
-      { deviceIds: ['classic-1'], name: 'Domicile' },
-      { deviceIds: ['home-1'], name: 'Chalet' },
+      { deviceIds: ['1000'], name: 'Domicile' },
+      { deviceIds: ['uuid-home-1'], name: 'Chalet' },
     ])
 
     await advancePastInit()
@@ -207,7 +209,7 @@ describe(MELCloudExtensionApp, () => {
       },
     })
     mockHomey.apiAppGet.mockReturnValue([
-      { deviceIds: ['classic-1', 'home-1'], name: 'Domicile' },
+      { deviceIds: ['1000', 'uuid-home-1'], name: 'Domicile' },
     ])
 
     await advancePastInit()
@@ -215,6 +217,30 @@ describe(MELCloudExtensionApp, () => {
     expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
       'classic-1': 'sensor-1:measure_temperature.outdoor',
       'home-1': 'sensor-1:measure_temperature.outdoor',
+    })
+  })
+
+  // A device whose data carries no usable MELCloud id cannot be joined
+  // to a building, so it has no siblings to inherit from and starts
+  // disabled — the same answer as an ungrouped one.
+  it('should default a newcomer without a usable join id to disabled', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    Object.assign(homeDevice.device, { data: {} })
+    const { mockHomey } = await createHarness([classicDevice, homeDevice], {
+      settings: {
+        hasSeededOutdoorSources: true,
+        outdoorSources: { 'classic-1': 'sensor-1:measure_temperature.outdoor' },
+      },
+    })
+    mockHomey.apiAppGet.mockReturnValue([
+      { deviceIds: ['1000', 'uuid-home-1'], name: 'Domicile' },
+    ])
+
+    await advancePastInit()
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': 'sensor-1:measure_temperature.outdoor',
+      'home-1': 'none',
     })
   })
 
@@ -227,7 +253,7 @@ describe(MELCloudExtensionApp, () => {
       },
     })
     mockHomey.apiAppGet.mockReturnValue([
-      { deviceIds: ['classic-1', 'home-1'], name: 'Domicile' },
+      { deviceIds: ['1000', 'uuid-home-1'], name: 'Domicile' },
     ])
 
     await advancePastInit()
@@ -242,7 +268,7 @@ describe(MELCloudExtensionApp, () => {
     const { classicDevice } = createDevices()
     const { app, mockHomey } = await createHarness([classicDevice])
     mockHomey.apiAppGet.mockReturnValue([
-      { deviceIds: ['classic-1'], name: 'Domicile' },
+      { deviceIds: ['1000'], name: 'Domicile' },
     ])
 
     await advancePastInit()


### PR DESCRIPTION
## What

`#inheritedSource` compared the wrong id space, so building inheritance has never worked.

## The bug

```ts
const group = this.#deviceGroups?.find(({ deviceIds }) =>
  deviceIds.includes(deviceId),   // deviceId is a HOMEY id…
)
```

…while `deviceIds` from com.melcloud's `/devices/groups` are **MELCloud** ids — `String(id)` off the Classic registry, the uuid on Home. The two spaces never intersect, so the lookup always missed, `siblingSources` was always empty, `size !== 1` held, and **every newcomer past the legacy seed silently landed on `DISABLED_SOURCE`** instead of inheriting its building's source. The behaviour documented in `CLAUDE.md:68-71` has never happened in production.

`lib/group-devices.mts` already gets this right — `toJoinKey(device.data.id)` — which is why the settings page groups correctly while the seeding does not.

## The fix

`toJoinKey` is exported and reused: the newcomer is matched on its MELCloud id, and its siblings are mapped **back** to Homey ids, because the settings map is keyed by those. A device whose data carries no usable id has no siblings and starts disabled, same as an ungrouped one.

## Why the tests missed it

`createMockDevice` defaults `data.id` to `id`, so both spaces read alike in every fixture — the tests were structurally incapable of catching this.

The AC fixtures now carry a MELCloud id **distinct** from their Homey id (`1000`, `uuid-home-1`), which is what production looks like, and the group payloads speak MELCloud ids. **Verified by mutation**: with those fixtures, reverting the join to the Homey id fails the two inheritance tests. Before, it passed everything.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm test` passes (185 tests, coverage 100% on statements, branches, functions and lines)
- [x] `npm run homey:validate` passes at `publish` level

No changelog entry: the fixed path only runs for devices added after this lands, and the user-visible effect is that a new unit inherits its building instead of arriving disabled — worth folding into the next release note rather than its own.