### PR TITLE
test: adopt the shared api-contract kernel

### DIFF
--- a/tests/unit/api-contract.test.ts
+++ b/tests/unit/api-contract.test.ts
@@ -3,23 +3,40 @@ import { describe, expect, expectTypeOf, it } from 'vitest'
 import appConfig from '../../.homeycompose/app.json' with { type: 'json' }
 import api from '../../api.mts'
 
+// The declaration half of the API contract: what the surface exposes
+// against what its manifest declares. The call-site half (every path a
+// webview writes, under a declared method) lives in
+// tests/unit/api-route-guards.test.ts.
+const SURFACES = [{ api, config: appConfig, name: 'app API' }]
+
+// The surface's handler union, so the compile-time half is asserted
+// once — this app exposes a single surface.
+type Handler = (typeof api)[keyof typeof api]
+
+// Everything below the SURFACES table is the shared contract test,
+// byte-identical in com.melcloud, com.heatzy and com.melcloud.extension
+// — edit all three together. Only the table and the Handler union above
+// differ: they name what each app exposes.
+
 const sortedKeys = (object: object): string[] =>
   Object.keys(object).toSorted((left, right) => left.localeCompare(right))
 
-// One equality pins the ids <-> handlers mapping in both directions at
-// once: a handler with no declaration and a declaration with no handler
-// both break it, and the diff names the offender. A per-id existence
-// sweep alongside it could only ever fail together with the equality,
-// so it is not kept.
 describe('api contract', () => {
-  // The compile-time half of the contract, asserted on the whole union
-  // at once: no per-name method reference ever leaves its object
-  // (unbound-method).
+  // Asserted on the whole union at once: no per-name method reference
+  // ever leaves its object (unbound-method).
   it('should expose only function handlers', () => {
-    expectTypeOf<(typeof api)[keyof typeof api]>().toBeFunction()
+    expectTypeOf<Handler>().toBeFunction()
   })
 
-  it('should declare exactly the handlers app.json names', () => {
-    expect(sortedKeys(api)).toStrictEqual(sortedKeys(appConfig.api))
-  })
+  // One equality per surface pins the ids ↔ handlers mapping in both
+  // directions at once: a handler with no declaration and a declaration
+  // with no handler both break it, and the diff names the offender. A
+  // per-id existence sweep alongside it could only ever fail together
+  // with the equality, so it is not kept.
+  it.each(SURFACES)(
+    '$name should declare exactly the handlers its manifest names',
+    ({ api: surfaceApi, config }) => {
+      expect(sortedKeys(surfaceApi)).toStrictEqual(sortedKeys(config.api))
+    },
+  )
 })


### PR DESCRIPTION
## What

Replaces this app's contract test with the kernel now shared by the three apps. Only the `SURFACES` table and the `Handler` union stay app-specific.

Companion PRs: OlivierZal/com.melcloud#1501 and OlivierZal/com.heatzy#1053.

## Why

The route guard was unified in #1225; its twin was left behind. Byte-identical copies edited together is the idiom the family already uses for `settings/callback-api.mts` and `settings/dirty-gate.mts`.

**No behaviour change here** — this copy was already byte-identical with com.heatzy's, so nothing had drifted between them. The shape comes from com.melcloud, where the change carries its weight: three repeated per-surface blocks collapse into one `it.each`, and the compile-time half is asserted once over a `Handler` union instead of per surface.

For this app it is a modest tidy (25 lines to 16) plus the family reading alike.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm test` passes (coverage 100%)
- [x] `npm run homey:validate` passes at `publish` level

Tests only.