### PR TITLE
fix: merge outdoor sources on write instead of replacing them

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -150,7 +150,13 @@ export default class MELCloudExtensionApp extends App {
         : toListenerData(payload)
     await this.#destroyListeners()
     this.homey.settings.set('isEnabled', isEnabled)
-    this.outdoorSources = outdoorSources
+    // Merged, never replaced: the settings page builds this payload from
+    // the devices it DISPLAYED, so a partial device list would drop the
+    // entries of the others. Merging is also the whole truth about this
+    // map — no key is ever legitimately removed (disabling a source is a
+    // value, `DISABLED_SOURCE`, not an absent entry), which is the same
+    // reason orphan entries are left alone.
+    this.outdoorSources = { ...this.outdoorSources, ...outdoorSources }
     if (!isEnabled) {
       return
     }

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -575,7 +575,39 @@ describe(MELCloudExtensionApp, () => {
     await app.autoAdjustCooling('garbage')
 
     expect(mockHomey.settingsStore.isEnabled).toBe(false)
-    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({})
+    // The sanitizer yields no sources, and that absence must not erase
+    // what seeding wrote: an off-shape body disables, it does not reset.
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+    })
+  })
+
+  // The settings page builds its payload from the devices it displayed,
+  // so an incomplete list must not take the others' entries down with it.
+  it('should keep the sources of devices the payload omits', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    const { app, mockHomey } = await createHarness(
+      [classicDevice, homeDevice],
+      {
+        settings: {
+          outdoorSources: {
+            'classic-1': 'sensor-1:measure_temperature',
+            'home-1': 'sensor-1:measure_temperature',
+          },
+        },
+      },
+    )
+
+    await advancePastInit()
+    await app.autoAdjustCooling({
+      isEnabled: false,
+      outdoorSources: { 'classic-1': null },
+    })
+
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': null,
+      'home-1': 'sensor-1:measure_temperature',
+    })
   })
 
   it('should log instead of crashing when the debounced reload fails', async () => {


### PR DESCRIPTION
## What

`app.mts` `autoAdjustCooling` now merges the incoming source map into the stored one instead of replacing it.

## Why

The settings page builds its PUT body from the devices it **displayed** (`getSelectedSources()` reads `sourceSelections`, which `populateSources` clears and refills per displayed device). Storing that verbatim means any device absent from the list loses its entry — and the entry's *presence* is load-bearing: `#seedOutdoorSources` uses `Object.hasOwn` to tell "never configured" from "explicitly set", so an erased entry makes the device a newcomer again.

This was the one open item from the earlier audit — flagged there as the only real risk found, and the same class of danger for which orphan pruning was refused, except already present and unguarded.

**The existing test made it vivid.** `should read an off-shape listener body as disabled without sources` asserted `outdoorSources` became `{}` after a garbage payload — that is, an invalid request body **erased the entire configuration** (`{classic-1: null}` → `{}`). It now asserts the seeded entry survives: an off-shape body disables, it does not reset.

## Why merging is right, not merely safe

No key is ever legitimately removed from this map:

- Disabling a source is a **value** (`DISABLED_SOURCE`), checked as such at `app.mts:159` — not an absent entry.
- Orphan entries are deliberately never pruned (recorded in CLAUDE.md, PR #1230).
- The two other write sites are already additive: `#migrateLegacySource` writes only when nothing is stored, `#seedOutdoorSources` mutates the map it just read.

So a merge is the operation this map has always wanted; the replacement was the anomaly.

## Verified by mutation

Restoring `this.outdoorSources = outdoorSources` fails both clauses — the updated off-shape one and the new `should keep the sources of devices the payload omits`.

## No changelog entry / version bump

In normal operation — full device list, well-formed body — the merge produces byte-identical results. The change only manifests in the failure paths it guards, so there is nothing store-facing to describe.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level