### PR TITLE
test: type the dirty-gate button doubles instead of asserting them

### DIFF
--- a/tests/dirty-gate.test.ts
+++ b/tests/dirty-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { createDirtyGate } from '../settings/dirty-gate.mts'
+import { mock } from './helpers.ts'
 
 // The gate is headless: buttons only need a `disabled` slot, and wired
 // targets only need to dispatch events, so plain doubles are enough.
@@ -10,8 +11,8 @@ const setup = (): {
   gate: ReturnType<typeof createDirtyGate>
   refreshElement: HTMLButtonElement
 } => {
-  const applyElement = { disabled: false } as unknown as HTMLButtonElement
-  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const applyElement = mock<HTMLButtonElement>({ disabled: false })
+  const refreshElement = mock<HTMLButtonElement>({ disabled: false })
   const form = { value: 'pristine' }
   const gate = createDirtyGate({
     applyElement,


### PR DESCRIPTION
## What

```diff
-  const applyElement = { disabled: false } as unknown as HTMLButtonElement
-  const refreshElement = { disabled: false } as unknown as HTMLButtonElement
+  const applyElement = mock<HTMLButtonElement>({ disabled: false })
+  const refreshElement = mock<HTMLButtonElement>({ disabled: false })
```

Third and last copy of a change that had to land in all three apps together. Companions: OlivierZal/com.melcloud#1504 and OlivierZal/com.heatzy#1055.

**This file was missed on the first pass** — it lives at `tests/dirty-gate.test.ts`, not `tests/unit/dirty-gate.test.ts` like its twins, so a `tests/unit/` sweep did not see it. After this PR the three copies are again one import line apart.

## Why

Measured on the com.melcloud twin rather than assumed:

| mutation | `as unknown as T` | `cast(...)` | `mock<T>({...})` |
|---|---|---|---|
| a key absent from the target type | not caught | not caught | **TS2353** |
| a wrong declared return type | TS2322 | not caught | **TS2322** |

The factory keeps the assignability check *and* adds key checking, with no assertion and no disable.

## `cast` is untouched here, deliberately

Its six uses in this repo are the *right* ones, and its own comment says why: it feeds a deliberately off-shape value where the type forbids one, so `to-outdoor-sources` / `to-thresholds` / `to-timestamped-logs` can be tested against what a hand-edited setting actually looks like (`cast('garbage')`, `cast({ 'classic-1': 42 })`).

That is the opposite need from building a typed double: there the value must be **invalid**, so key checking would defeat the test. Same helper, two jobs, and only one of them is a hack.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level

Tests only, no source change.