### PR TITLE
chore: release 25.1.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -436,5 +436,20 @@
     "pl": "Aplikacja nie wysyła już 0 °C, gdy brakuje zapisanej temperatury: nic nie wysyła i podaje powód w dzienniku.",
     "ru": "Приложение больше не отправляет 0 °C, когда сохранённая температура отсутствует: оно ничего не отправляет и указывает причину в журнале.",
     "sv": "Appen skickar inte längre 0 °C när din sparade temperatur saknas: den skickar ingenting och anger orsaken i loggen."
+  },
+  "25.1.1": {
+    "ar": "حفظ إعدادات التبريد لم يعد يمحو مصدر درجة الحرارة الخارجية للأجهزة التي لم تكن معروضة في الصفحة.",
+    "da": "Når du gemmer dine køleindstillinger, slettes udetemperatur-kilden for enheder, der ikke blev vist på siden, ikke længere.",
+    "de": "Beim Speichern der Kühleinstellungen wird die Außentemperatur-Quelle von Geräten, die nicht auf der Seite angezeigt wurden, nicht mehr gelöscht.",
+    "en": "Saving your cooling settings no longer clears the outdoor temperature source of devices that were not shown on the page.",
+    "es": "Al guardar tus ajustes de refrigeración ya no se borra la fuente de temperatura exterior de los dispositivos que no aparecían en la página.",
+    "fr": "Enregistrer vos réglages de refroidissement n'efface plus la source de température extérieure des appareils qui n'étaient pas affichés sur la page.",
+    "it": "Il salvataggio delle impostazioni di raffreddamento non cancella più la fonte della temperatura esterna dei dispositivi non mostrati nella pagina.",
+    "ko": "냉방 설정을 저장할 때 페이지에 표시되지 않은 기기의 외기 온도 소스가 더 이상 지워지지 않습니다.",
+    "nl": "Bij het opslaan van je koelinstellingen wordt de buitentemperatuurbron van apparaten die niet op de pagina stonden niet meer gewist.",
+    "no": "Når du lagrer kjøleinnstillingene, slettes ikke lenger utetemperatur-kilden for enheter som ikke ble vist på siden.",
+    "pl": "Zapisanie ustawień chłodzenia nie usuwa już źródła temperatury zewnętrznej urządzeń, które nie były widoczne na stronie.",
+    "ru": "Сохранение настроек охлаждения больше не стирает источник наружной температуры устройств, которые не отображались на странице.",
+    "sv": "När du sparar dina kylinställningar rensas inte längre källan för utetemperatur för enheter som inte visades på sidan."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -194,5 +194,5 @@
       "värmepump"
     ]
   },
-  "version": "25.1.0"
+  "version": "25.1.1"
 }

--- a/app.json
+++ b/app.json
@@ -195,5 +195,5 @@
       "värmepump"
     ]
   },
-  "version": "25.1.0"
+  "version": "25.1.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.1.0",
+  "version": "25.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "25.1.0",
+      "version": "25.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.1.0",
+  "version": "25.1.1",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
## What

Releases the outdoor-source write fix from #1234.

- `.homeychangelog.json`: new `25.1.1` key, all 13 locales (15 insertions, 0 deletions — the rest of the file is byte-identical).
- `.homeycompose/app.json`: `version` → `25.1.1`.
- `package.json` aligned via `npm version 25.1.1 --no-git-tag-version`.
- `app.json` regenerated by `homey:validate`, committed in the CLI's own form.

## Why this is the only repo being released

Checked all five against their last release tag, excluding tests, CI and docs:

| repo | shippable change since last release |
|---|---|
| **com.melcloud.extension** | **`app.mts` — the fix** |
| com.melcloud | none — `types/app-settings.mts` (compile-time only) plus devDependency bumps; `@olivierzal/melcloud-api` still pinned at `45.1.0` |
| com.heatzy | none |
| melcloud-api | none — `undici` floor moved `^8.7.0` → `^8.8.0`, which consumers already resolve to, and `npm audit --omit=dev` reports 0 vulnerabilities |
| heatzy-api | none — `prettier` only |

The new melcloud-api contract suites are **tests only**: they changed no source, so there is no library version to bump and nothing to propagate to com.melcloud.

## Changelog wording

Non-technical and store-facing, matching the app's own vocabulary (`outdoor temperature` / `température extérieure`, taken from `locales/*.json` rather than invented):

> Saving your cooling settings no longer clears the outdoor temperature source of devices that were not shown on the page.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run homey:validate` passes at `publish` level