### PR TITLE
chore: close the parity gaps the wave left

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,9 @@ jobs:
     # non-blocking so a brand-new Node release cannot red the pipeline
     # without any repo change.
     continue-on-error: ${{ matrix.node-version == 'latest' }}
+    # Job-level so the Sonar step can gate on the secret's presence: the
+    # `secrets` context is not available in a step-level `if`, `env` is.
     env:
-      # Job-level so the step `if` can gate on it (the secrets context is
-      # not available in step conditions): the Sonar upload self-arms the
-      # moment the SONAR_TOKEN secret exists.
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     name: Test (Node ${{ matrix.node-version }})
     permissions:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -63,7 +63,7 @@ jobs:
                cause and the needed fix.
     timeout-minutes: 30
 name: Claude Dependabot Fix
-on: # zizmor: ignore[dangerous-triggers]
+on:
   workflow_run:
     types: [completed]
     workflows: [CI, Validate]

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  # workflow_run is deliberate there: it is the only trigger that keeps
+  # CLAUDE_CODE_OAUTH_TOKEN out of dependabot's reach (see the header
+  # comment in the workflow), and the job gates on the dependabot actor.
+  dangerous-triggers:
+    ignore:
+      - claude-dependabot-fix.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,9 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
 - `.homeycompose/` is the SOURCE for `app.json` and `locales/*.json`;
   commit the CLI-generated outputs verbatim (no trailing newline).
 - App-API surface conventions (aligned on com.melcloud): paths are
-  kebab-case REST, `get*` for GET; `fetch*` in the webview is reserved
+  kebab-case REST, `get*` for GET — except `is*` for a boolean GET —,
+  `update*` for PUT, a business verb for POST (`logWebviewBoot` on
+  `/boot-error`); `fetch*` in the webview is reserved
   for transport calls (`load*` reads the settings store). The
   auto-adjustment path is `/cooling/auto-adjustment` (the snake_case
   legacy alias was dropped by decision, 2026-07 — a cached pre-rename
@@ -234,6 +236,26 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
   (unit-dependent); poll it (no push events), readings are sanitized by
   `lib/to-temperature.mts` (anything non-finite reads as null, never
   0/NaN).
+
+## Naming & authored-content conventions
+
+- What `@typescript-eslint/naming-convention` cannot see is convention
+  too: booleans read as questions even untyped (`isX`/`hasX`), handlers
+  as verbs; a name states what the thing IS, never its history. Test
+  files are named after the unit under test (`<module>.test.ts`); shared
+  test helpers keep their family's names — apps say `assertDefined` and
+  `mock(overrides)` where the libraries say `defined` and
+  `mock(value?)`: two test families, deliberately not unified.
+- Static markup and styles live in `.html`/`.css` files. TS builds DOM
+  only when the content is programmatic (computed values, per-item
+  nodes), via `createElement` — never `innerHTML` (`no-unsafe-dom-html`
+  enforces it). Inline style writes are reserved for values CSS cannot
+  express; anything static belongs in the stylesheet, following the
+  CSS/HTML lint rules' spirit even where no rule captures it.
+- The webview runtime floor (es2023, no `Object.groupBy`, no iterator
+  helpers) is enforced by a scoped lint block over `settings/` — the
+  tsconfig cannot express two runtimes in one project. Node-side code
+  may use the newer APIs freely.
 
 ## Lint doctrine
 


### PR DESCRIPTION
Final sweep after the audit wave: three repo-wide promises had landed only in com.melcloud.

1. **The webview-floor lint guard** — this app has the same es2023-constrained settings webview; the guard is mutation-verified here too (`Object.groupBy` probe caught, restored).
2. **The naming & authored-content doctrine sections** (naming beyond the eslint rule, static-vs-programmatic markup, the floor's enforcement note).
3. **The completed route conventions** — `is*` boolean GETs and business-verb POSTs, practiced by the surfaces since their harmonization but documented only in com.melcloud.

Suite green: format/lint/typecheck/coverage 100%/homey:validate.