### PR TITLE
docs: the one name the rename sweep missed

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -55,7 +55,7 @@ const config: Config[] = defineConfig([
       '.homeybuild/',
       'coverage/',
       // Stale local bundle from builds predating the `.homeybuild`
-      // emission (bundle.mjs deletes it on its next run); without the
+      // emission (bundle.mts deletes it on its next run); without the
       // entry a never-rebuilt tree would get swept by lint.
       'settings/index.mjs',
     ],


### PR DESCRIPTION
A final review swept the five repos for identifiers left stale by the wave's renames (`autoAdjustCooling`, `bundle.mjs`, `sync-capability-definitions.mjs`, `logWebview`, dynamic `import(`). Single hit: this comment. Everything else verified in the same pass: the six shared kernels byte-identical, the dirty-gate twins at their documented one-line gap, the new artifacts (`zizmor.yml`, `extensions.json`, `.nvmrc`, `SECURITY.md`) in parity across the five, and every claim the new doctrine sections make measured true (`no-unsafe-dom-html` at error in the three apps, `defined` present in both libraries).