### PR TITLE
ci: align the workflow family to one form

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,3 +1,6 @@
+# Serialize runs per ref (a manual dispatch racing the weekly schedule)
+# without cancelling in-progress audits — an interrupted audit reports
+# nothing, so letting each run finish is strictly more informative.
 concurrency:
   cancel-in-progress: false
   group: audit-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         run: npm test -- --coverage
       - if: matrix.node-version != 22
         run: npm test
+      # Self-armed on the secret: until SONAR_TOKEN is provisioned the
+      # upload skips instead of failing the leg.
       - if: matrix.node-version == 22 && env.SONAR_TOKEN != '' && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f
     strategy:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
         with:
           claude_args: --model opus
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/setup-node-and-install
         with:
           npm-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
         with:
           additional_permissions: |
             actions: read
@@ -66,5 +66,6 @@ name: Claude Dependabot Fix
 on:
   workflow_run:
     types: [completed]
+    # The repo's two always-running required build gates (see ruleset).
     workflows: [CI, Validate]
 permissions: {}

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
         with:
           allowed_non_write_users: '*'
           claude_args: >-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
         with:
           additional_permissions: |
             actions: read
@@ -31,6 +31,8 @@ jobs:
     timeout-minutes: 15
 name: Claude
 on:
+  # No pull_request_review(_comment): Copilot auto-review fires them as a
+  # write-less bot, piling up held runs the if-guard would skip anyway.
   issue_comment:
     types: [created]
   issues:


### PR DESCRIPTION
One slice of a five-repo alignment (same title everywhere). A hash matrix of every workflow across the repos found the last drifts — action pins behind in two repos, three rationale comments on one side of the family only, an undocumented `workflows:` gate list, split matrix quoting. After the five PRs: **zizmor, claude, claude-code-review and claude-issue-triage are byte-identical across all five repos**; ci and audit are identical within each family; every remaining cross-family difference is auth or domain, verified by diff. `zizmor` locally clean on all five.