### PR TITLE
chore: adopt eslint-plugin-unicorn 73

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -743,6 +743,7 @@ const config: Config[] = defineConfig([
       'unicorn/id-match': 'off',
       // Vocabulary opt-out: the abbreviation renames it forces
       // (`args` -> `arguments_`, ...) fight the domain naming.
+      'unicorn/iteration-fallback-style': 'error',
       'unicorn/name-replacements': 'off',
       // Owned by `import-x/no-anonymous-default-export`.
       'unicorn/no-anonymous-default-export': 'off',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -741,9 +741,9 @@ const config: Config[] = defineConfig([
       'unicorn/custom-error-definition': 'error',
       // Owned by `@typescript-eslint/naming-convention`.
       'unicorn/id-match': 'off',
+      'unicorn/iteration-fallback-style': 'error',
       // Vocabulary opt-out: the abbreviation renames it forces
       // (`args` -> `arguments_`, ...) fight the domain naming.
-      'unicorn/iteration-fallback-style': 'error',
       'unicorn/name-replacements': 'off',
       // Owned by `import-x/no-anonymous-default-export`.
       'unicorn/no-anonymous-default-export': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-plugin-jsdoc": "^63.3.3",
         "eslint-plugin-package-json": "^1.6.0",
         "eslint-plugin-perfectionist": "^5.10.0",
-        "eslint-plugin-unicorn": "^72.0.0",
+        "eslint-plugin-unicorn": "^73.0.0",
         "eslint-plugin-yml": "^3.6.0",
         "homey-apps-sdk-v3-types": "^0.3.12",
         "jiti": "^2.7.0",
@@ -3718,9 +3718,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "72.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
-      "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
+      "version": "73.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-73.0.0.tgz",
+      "integrity": "sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-jsdoc": "^63.3.3",
     "eslint-plugin-package-json": "^1.6.0",
     "eslint-plugin-perfectionist": "^5.10.0",
-    "eslint-plugin-unicorn": "^72.0.0",
+    "eslint-plugin-unicorn": "^73.0.0",
     "eslint-plugin-yml": "^3.6.0",
     "homey-apps-sdk-v3-types": "^0.3.12",
     "jiti": "^2.7.0",


### PR DESCRIPTION
## What

`eslint-plugin-unicorn` `^72` → `^73`, with every new rule settled on **measured evidence** (v73 probed against the real sources before any verdict) — one PR per repo, same title.

| rule | preset | violations (family) | verdict |
|---|---|---|---|
| `single-line-block-comment-style` | auto-on | 326 | **adopted** — single-line JSDoc → canonical 3-line form |
| `no-unsafe-sqlite-interpolation` | auto-on | 0 | inert (no sqlite), free protection |
| `iteration-fallback-style` | opt-in | 0 | **adopted at error** — free guard, mutation-verified |
| `consistent-arrow-return-style` | opt-in | ~496 | **refused** — multiline implicit return is the house idiom |
| `no-barrel-files` | opt-in | 28 | **refused** — the barrels ARE the public API (`exports` map, publint-validated); the anti-barrel cost model targets bundled apps with deep transitive graphs, not a small Node-loaded library. Revisit if the library is ever bundled. |

## The autofix incident, and why the diff is script-made

`eslint --fix` for the comment rule **interacting with `multiline-comment-style: separate-lines`** produced two damage shapes instead of the approved preview: doc comments degraded to bare `//` triples (JSDoc semantics lost — typedoc, IDE hover), and expansions without the `*` prefix. Both were caught, reverted, and the expansion re-done by a **deterministic script**: `/** X */` → the canonical 3-line form.

**Purity proven**: the JSDoc diff touches **zero non-comment lines** (measured), and `npm run docs` (typedoc) passes on the rebuilt comments.

## Ledger movement (libraries)

- `no-this-outside-of-class` off **lifted**: v73 allows explicit TypeScript `this` parameters — exactly the decorator-protocol reason the entry documented. Zero violations with the rule live; a genuine violation (undeclared `this`) fires. One documented disable less.
- `no-nonstandard-builtin-properties` off **stays**: still flags `Symbol.dispose` (17+13 sites), the documented reason remains true.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] apps: `homey:validate` at publish level · libs: `lint:package` + `docs` pass
