### PR TITLE
build(deps-dev): bump transitive postcss to 8.5.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6305,9 +6305,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -6325,7 +6325,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
GHSA advisory (moderate, dev scope): postcss <= 8.5.22 reads arbitrary `.map` files through an attacker-controlled `sourceMappingURL` when `from` is unset — incomplete fix of GHSA-6g55-p6wh-862q, patched in 8.5.23. Lockfile-only refresh (`npm update postcss`); postcss is not a direct dependency. Full suite green.

The same bump lands across the family: com.melcloud is already on 8.5.25; melcloud-api and heatzy-api follow once their in-flight dependency PRs merge, to avoid lockfile conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
