### PR TITLE
build(deps): bump transitive socket.io-parser to 3.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6580,9 +6580,9 @@
       "license": "MIT"
     },
     "node_modules/socket.io-parser": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.5.tgz",
-      "integrity": "sha512-pn+xG/oVnofxqteOawycpHw9QKclpNRa+Z7RW0vZmrIpkgZOVSVzBvY1YGR+p9kIEZXkeAjpHa21wRNLCZ6UAA==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.6.tgz",
+      "integrity": "sha512-+VwteZF0qtYVkcO1nhKf6ZUVz5wq6Ya+Lx10y3Y81Sp5+iyGGY2GTcd81W36C/r1tjP+GhXjiXaLKlCMyE+yHQ==",
       "license": "MIT",
       "dependencies": {
         "component-emitter": "~1.3.0",


### PR DESCRIPTION
CVE-2026-69185 / GHSA-2m8v-j782-fhvr (high, runtime scope): zero-attachment memory exhaustion in socket.io-parser < 3.3.6, patched in 3.3.6. The parser reaches the app through `homey-api` → `socket.io-client@2.5.0`, whose `~3.3.0` range accepts the patch — lockfile-only refresh (`npm update socket.io-parser`). Full suite green, `homey:validate` included.

Closes the Dependabot alert OlivierZal/com.melcloud.extension#41 (the only repo of the family shipping `homey-api`, hence the only one affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
