### PR TITLE
docs: restore the load-bearing store-link typo and pin it in doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,15 @@ dependency is WIRE-LEVEL, against whatever com.melcloud version is
 installed alongside, and it is one-directional (com.melcloud never calls
 back). The consumed surface, exhaustively:
 
+- The app ids themselves carry the original submissions' typo, and it
+  is LOAD-BEARING: this app is `com.mecloud.extension` and addresses
+  the main app as `com.mecloud` (`MELCLOUD_APP_ID`, `app.mts`). A
+  platform id cannot change without orphaning every install, so the
+  store URLs keep the typo too (`https://homey.app/a/com.mecloud`,
+  `https://homey.app/a/com.mecloud.extension`). Never "fix" the
+  missing `l` anywhere — manifest, code or docs links (a README "fix"
+  once turned all three store links into 404s; reverted, 2026-08).
+
 - `GET /devices/groups` on com.melcloud's app API — the building
   grouping. The contract is DEGRADE, never fail: an absent route (older
   com.melcloud, app not installed) or an off-shape payload reads as "no

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Extension for MELCloud Homey App
 
-A [Homey](https://homey.app/) app extending the [MELCloud app](https://homey.app/a/com.melcloud) with automatic cooling adjustment based on the outdoor temperature.
+A [Homey](https://homey.app/) app extending the [MELCloud app](https://homey.app/a/com.mecloud) with automatic cooling adjustment based on the outdoor temperature.
 
 [![License](https://img.shields.io/github/license/OlivierZal/com.melcloud.extension)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/OlivierZal/com.melcloud.extension?sort=semver)](https://github.com/OlivierZal/com.melcloud.extension/releases)
@@ -24,9 +24,9 @@ Why?
 ## Usage
 
 1. You must have a Homey Pro.
-2. Install the [MELCloud Homey app](https://homey.app/a/com.melcloud) from the Homey App Store.
+2. Install the [MELCloud Homey app](https://homey.app/a/com.mecloud) from the Homey App Store.
 3. Pair your devices.
-4. Install the [MELCloud Homey app extension](https://homey.app/a/com.melcloud.extension) from the Homey App Store.
+4. Install the [MELCloud Homey app extension](https://homey.app/a/com.mecloud.extension) from the Homey App Store.
 5. Configure the outdoor temperature source of each MELCloud building in the settings of the MELCloud Homey app extension.
 
 ## Supported languages


### PR DESCRIPTION
The App Store links spell `com.mecloud` because that **is** the published app id — the original submission's typo, now load-bearing: a platform id cannot change without orphaning every install, and everything derives from it (store URL, `MELCLOUD_APP_ID` in the extension). The previous README pass "corrected" the links into 404s.

Verified before restoring: `.homeycompose/app.json` declares `com.mecloud` / `com.mecloud.extension`, `https://homey.app/a/com.mecloud` answers 200 while `.../com.melcloud` answers 404. The trap is now pinned in CLAUDE.md (both repos) so it cannot be "fixed" again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
