### PR TITLE
docs: align the README with its family and pin docs currency in doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,9 +311,9 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
 ## Repo process
 
 - Companion docs are part of a change's definition of done: a PR that
-  changes behavior, surface, requirements or process updates the
-  affected companion files (README.md, CONTRIBUTING.md, SECURITY.md,
-  CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
+  changes behavior, API surface, requirements or process must update
+  the affected companion files (README.md, CONTRIBUTING.md,
+  SECURITY.md, CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
   README audit caught exactly the drift this prevents (a shipped Home
   ATW driver absent from its README, a stale `Result` kind list).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,13 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
 
 ## Repo process
 
+- Companion docs are part of a change's definition of done: a PR that
+  changes behavior, surface, requirements or process updates the
+  affected companion files (README.md, CONTRIBUTING.md, SECURITY.md,
+  CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
+  README audit caught exactly the drift this prevents (a shipped Home
+  ATW driver absent from its README, a stale `Result` kind list).
+
 - Design phases (on Olivier's call, start and end): iterate on
   `design/*` branches with dev-installs only — no PR merges, no tags,
   no releases, no App Store publishes until he lifts the pause.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm run homey:start  # run the app on your Homey (remote)
 Architecture notes:
 
 - The MELCloud dependency is wire-level, not npm: devices are reached through Homey's local API (`homey-api`), buildings through the MELCloud app's own API (app id `com.mecloud`), and every consumed shape is sanitized at entry so version skew degrades instead of failing.
-- The settings page (`settings/`) is bundled by `scripts/bundle.mts` into a classic IIFE `settings/index.js`, plus an ESM twin `settings/index.mjs` kept for phone-cached copies of the page (shipped bundle filenames are a compatibility contract); the outputs are gitignored and rebuilt by `npm run build`, which the Homey CLI runs automatically on validate/publish.
+- The settings page (`settings/`) is bundled by `scripts/bundle.mts` into a compat pair — a classic IIFE `index.js` (what the shipped HTML loads) plus an ESM twin `index.mjs` for phone-cached copies of the page (shipped bundle filenames are a compatibility contract) — emitted into `.homeybuild`, the packaged app, never into the source tree; `npm run build` produces them, and the Homey CLI runs it automatically on validate/publish.
 - Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`typescript@7` aliased as `@typescript/native`) for speed; `typescript@6` remains alongside it for tools that need the JS API (typescript-eslint).
 - Test coverage is enforced at 100% for backend code; browser glue (`settings/`) is excluded from coverage.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm run homey:start  # run the app on your Homey (remote)
 
 Architecture notes:
 
+- The MELCloud dependency is wire-level, not npm: devices are reached through Homey's local API (`homey-api`), buildings through the MELCloud app's own API (app id `com.mecloud`), and every consumed shape is sanitized at entry so version skew degrades instead of failing.
 - The settings page (`settings/`) is bundled by `scripts/bundle.mts` into a classic IIFE `settings/index.js`, plus an ESM twin `settings/index.mjs` kept for phone-cached copies of the page (shipped bundle filenames are a compatibility contract); the outputs are gitignored and rebuilt by `npm run build`, which the Homey CLI runs automatically on validate/publish.
 - Both the build and `npm run typecheck` use the native TypeScript 7 compiler (`typescript@7` aliased as `@typescript/native`) for speed; `typescript@6` remains alongside it for tools that need the JS API (typescript-eslint).
 - Test coverage is enforced at 100% for backend code; browser glue (`settings/`) is excluded from coverage.


### PR DESCRIPTION
Family-alignment audit of the five READMEs, by repo nature (API lib vs Homey app), plus the docs-currency doctrine rule. Per repo: melcloud-api gains the `Validated boundaries` feature bullet its heatzy-api twin already had (zod guards its payloads too — `src/validation/schemas.ts`) and the docs badge loses its stale `?v=2`; com.melcloud gains the API-layer architecture bullet com.heatzy already had; the extension gains its nature's equivalent (wire-level dependency, app id `com.mecloud`); and all five doctrines now state that companion docs (README, CONTRIBUTING, SECURITY, CLAUDE.md) are updated in the same PR as the change they describe — the 2026-08 README audit caught exactly the drift this prevents. Remaining cross-family differences are deliberate and code-backed (Error handling and Imports sections only where `Result` and subpath exports exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
