### PR TITLE
docs: make the PR the explicit subject of the docs-currency rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,12 +310,12 @@ start`. Never rename or drop a shipped bundle filename; add alongside.
 
 ## Repo process
 
-- Companion docs are part of a change's definition of done: a PR that
-  changes behavior, API surface, requirements or process must update
-  the affected companion files (README.md, CONTRIBUTING.md,
-  SECURITY.md, CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
-  README audit caught exactly the drift this prevents (a shipped Home
-  ATW driver absent from its README, a stale `Result` kind list).
+- Companion docs are part of a change's definition of done: whenever a
+  PR changes behavior, API surface, requirements or process, the same
+  PR updates the affected companion files (README.md, CONTRIBUTING.md,
+  SECURITY.md, CLAUDE.md) — never a later sweep; the 2026-08 README
+  audit caught exactly the drift this prevents (a shipped Home ATW
+  driver absent from its README, a stale `Result` kind list).
 
 - Design phases (on Olivier's call, start and end): iterate on
   `design/*` branches with dev-installs only — no PR merges, no tags,


### PR DESCRIPTION
Same rewording as the three sibling PRs (raised again by Copilot there): the verb phrase could still attach to "process". The subordinate-first form ("whenever a PR changes …, the same PR updates …") leaves no ambiguous parse, and the paragraph is byte-identical across the five doctrines again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
