### PR TITLE
fix: clear the review-confirmed residue

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,4 @@
 /app.json
 /locales/
 /README.md
-/settings/index.mjs
 /.claude/

--- a/app.mts
+++ b/app.mts
@@ -420,16 +420,19 @@ export default class MELCloudExtensionApp extends App {
     )
   }
 
-  #reconcileSourceEntries(): void {
-    this.#migrateLegacySource()
-    this.#seedOutdoorSources()
-  }
-
   // Every known AC device gets an EXPLICIT outdoor-source entry, so a
   // device appearing later is distinguishable from one whose entry was
   // never written. The first seeding on an existing install stamps the
   // legacy default (null = Homey weather) and changes nothing;
   // afterwards newcomers go through #inheritedSource.
+  // Brings the per-device source entries in line with the freshly
+  // loaded device set: the legacy single-source form migrates first so
+  // seeding sees its result, and newcomers start disabled (opt-in).
+  #reconcileSourceEntries(): void {
+    this.#migrateLegacySource()
+    this.#seedOutdoorSources()
+  }
+
   #seedOutdoorSources(): void {
     const stored: OutdoorSources = this.outdoorSources
     const newcomers = this.#melcloudDevices.filter(

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -54,9 +54,10 @@ const config: Config[] = defineConfig([
     ignores: [
       '.homeybuild/',
       'coverage/',
-      // Stale local bundle from builds predating the `.homeybuild`
-      // emission (bundle.mts deletes it on its next run); without the
-      // entry a never-rebuilt tree would get swept by lint.
+      // Pre-`.homeybuild` leftovers in never-rebuilt trees: gitignored,
+      // and ignored here so a stale tree cannot break the lint run.
+      'settings/index.js',
+      'settings/index.mjs',
     ],
   },
   {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -57,7 +57,6 @@ const config: Config[] = defineConfig([
       // Stale local bundle from builds predating the `.homeybuild`
       // emission (bundle.mts deletes it on its next run); without the
       // entry a never-rebuilt tree would get swept by lint.
-      'settings/index.mjs',
     ],
   },
   {

--- a/listeners/melcloud.mts
+++ b/listeners/melcloud.mts
@@ -30,10 +30,6 @@ const MAX_TEMPERATURE = 31
 // changes and automatically adjusts the target cooling temperature
 // based on its outdoor source readings.
 export class MELCloudListener {
-  public get isCooling(): boolean {
-    return this.#thermostatModeListener?.value === COOL
-  }
-
   readonly #app: MELCloudExtensionApp
 
   readonly #device: HomeyAPIV3Local.ManagerDevices.Device

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -7,7 +7,7 @@
 // (temporal-polyfill) are inlined so the webview works offline with
 // versions pinned by the lockfile.
 import { createHash } from 'node:crypto'
-import { readFile, rm, writeFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { type BuildOptions, build } from 'esbuild'
@@ -30,9 +30,7 @@ const entryPoints = ['settings/index.mts']
 const pages = [{ entry: 'settings', page: 'settings/index.html' }]
 
 // A local asset reference — an href/src attribute value, with an
-// optional existing stamp. (A dynamic-import alternative once lived
-// here: dead since the classic-defer fix, no shipped HTML uses
-// `import()` any more.)
+// optional existing stamp.
 const REFERENCE =
   /(?<prefix>href="|src=")(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>")/gv
 
@@ -63,19 +61,6 @@ await Promise.all(
       }),
     ]
   }),
-)
-
-// Courtesy cleanup: builds predating the `.homeybuild` emission left
-// bundles in the source tree; they only linger confusingly there.
-await Promise.all(
-  entryPoints.flatMap((entryPoint) =>
-    ['.js', '.mjs'].map(async (extension) =>
-      rm(
-        entryPoint.replace(/\.mts$/v, () => extension),
-        { force: true },
-      ),
-    ),
-  ),
 )
 
 // Cache-bust the PACKAGED page: phone webviews cache assets across app

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -703,7 +703,7 @@ const populateSources = async (homey: Homey): Promise<void> => {
 }
 
 // Spread (not `.entries().map()`): iterator helpers are a 2025-era
-// runtime API, far above the webview's es2020 floor — esbuild lowers
+// runtime API, far above the webview's es2023 floor — esbuild lowers
 // syntax only, never runtime APIs.
 const getSelectedSources = (): OutdoorSources =>
   Object.fromEntries(

--- a/settings/webview-freshness.mts
+++ b/settings/webview-freshness.mts
@@ -2,8 +2,8 @@
 // cached across app versions — the HTML itself included (proven in the
 // wild), so a booted page may run stale UI code indefinitely: the
 // cached HTML's `?v=` stamps keep serving the matching cached assets.
-// The page's identity is the SORTED JOIN of every `?v=` stamp it
-// carries (so a CSS-only or markup-only ship moves it too); the app
+// The page's identity is the DOCUMENT-ORDER join of every `?v=` stamp
+// it carries (so a CSS-only or markup-only ship moves it too); the app
 // serves the live identities (`GET /webview-hashes`, emitted at
 // package time), fetched through the app bridge so no HTTP cache can
 // stale them. On mismatch the page reloads ONCE — the reload

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.projectKey=OlivierZal_com.melcloud.extension
 sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.exclusions=**/*.jpg,**/*.png,coverage/**,settings/index.mjs
+sonar.exclusions=**/*.jpg,**/*.png,coverage/**
 sonar.coverage.exclusions=tests/**,**/*.config.*,settings/**,scripts/**
 sonar.cpd.exclusions=**/*.config.*

--- a/tests/unit/melcloud-listener.test.ts
+++ b/tests/unit/melcloud-listener.test.ts
@@ -134,7 +134,6 @@ describe(MELCloudListener, () => {
     expect(
       harness.mockDevice.capabilityInstances.has('target_temperature'),
     ).toBe(false)
-    expect(harness.listener.isCooling).toBe(false)
   })
 
   it('should floor the target to the outdoor temperature minus the gap, half-degree precise', async () => {
@@ -246,7 +245,6 @@ describe(MELCloudListener, () => {
     expect(
       harness.mockDevice.capabilityInstances.has('target_temperature'),
     ).toBe(true)
-    expect(harness.listener.isCooling).toBe(false)
   })
 
   it('should not rearm the target listener when cool is reported twice', async () => {
@@ -366,14 +364,6 @@ describe(MELCloudListener, () => {
       idOrName: 'Living room',
       type: 'Device',
     })
-  })
-
-  it('should report cooling from the live thermostat mode', async () => {
-    const harness = createHarness()
-
-    await harness.listener.listenToThermostatMode()
-
-    expect(harness.listener.isCooling).toBe(true)
   })
 
   it('should destroy both capability listeners and revert', async () => {

--- a/types.mts
+++ b/types.mts
@@ -14,7 +14,7 @@ export interface AdjustableGroup {
   readonly name: string | null
 }
 
-// Payload served by com.melcloud's /device_groups endpoint
+// Payload served by com.melcloud's /devices/groups endpoint
 export type DeviceGroups = readonly {
   readonly deviceIds: readonly string[]
   readonly name: string


### PR DESCRIPTION
Wave 3 of the five-repo residue review (every finding re-verified). The `DeviceGroups` comment named a `/device_groups` endpoint that never existed (`/devices/groups` everywhere else); a settings comment cited an es2020 floor where the doctrine says es2023; the `isCooling` getter had no production caller — the outdoor source's subscriber registry is what answers "which devices cool" — and its three test assertions go with it; the freshness twin's header now says document-order join like its implementation; the source-tree bundle crutch (rm block + ignore entries) is pruned, `.gitignore` keeping the lasting guard. One finding refuted on evidence: inlining `#reconcileSourceEntries` broke the `max-statements` cap on `#loadDevices` — the indirection is metric-forced and now carries the invariant comment it lacked instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
