### PR TITLE
refactor: clear the round-2 review residue

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,8 @@
 /app.json
 /locales/
 /README.md
+# Pre-`.homeybuild` leftovers in never-rebuilt trees: gitignored, and
+# ignored here so a stale tree cannot break the format run.
+/settings/index.js
+/settings/index.mjs
 /.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,10 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   force-close included): each bundle carries a freshness handshake —
   the page's identity is the document-order join of its `?v=` stamps (a CSS-only ship moves it too), `GET /webview-hashes` serves the
   live hashes (a manifest `bundle.mts` emits into the packaged app,
-  read by `lib/webview-hashes.mts`), and a mismatch triggers ONE
+  read by `lib/webview-hashes.mts`; module, test
+  `tests/unit/webview-hashes.test.ts` and the
+  `tests/fixtures/webview-hashes/` fixtures are byte-identical in the
+  three apps — edit all three together), and a mismatch triggers ONE
   `location.reload()` (sessionStorage guard, `webview-freshness.mts`),
   which revalidates the HTML and pulls the fresh bundle. Every failure
   path stays open: an unstamped page, an absent route or denied

--- a/api.mts
+++ b/api.mts
@@ -72,8 +72,9 @@ const api = {
    * @throws {@link NotFoundError} when no MELCloud AC device is paired yet.
    */
   getTemperatureSensors({ homey }: { homey: Homey }): TemperatureSensor[] {
-    const { melcloudDevices, temperatureSensors } = homey.app
-    logSettingsRoute(homey.app, '/devices/sensors/temperature')
+    const { app } = homey
+    const { melcloudDevices, temperatureSensors } = app
+    logSettingsRoute(app, '/devices/sensors/temperature')
     if (melcloudDevices.length === 0) {
       throw new NotFoundError()
     }
@@ -98,11 +99,19 @@ const api = {
   /**
    * Serves the packaged webview-bundle hashes so a booted page can
    * detect a stale cached copy of itself and reload once.
+   * @param options - Homey API context.
+   * @param options.homey - Homey instance carrying the app.
    * @returns The bundle hash per page entry; empty outside the
    * packaged flow.
    */
-  getWebviewHashes: async (): Promise<Partial<Record<string, string>>> =>
-    getWebviewHashes(),
+  async getWebviewHashes({
+    homey: { app },
+  }: {
+    homey: Homey
+  }): Promise<Partial<Record<string, string>>> {
+    logSettingsRoute(app, '/webview-hashes')
+    return getWebviewHashes()
+  },
   logWebviewBoot: ({
     body,
     homey: { app },
@@ -125,6 +134,7 @@ const api = {
     body: TemperatureListenerData
     homey: Homey
   }): Promise<void> {
+    logSettingsRoute(app, '/cooling/auto-adjustment')
     await app.autoAdjustCooling(body)
   },
 }

--- a/app.mts
+++ b/app.mts
@@ -160,11 +160,16 @@ export default class MELCloudExtensionApp extends App {
     if (!isEnabled) {
       return
     }
+    // The restart routes from the merged map for the same reason: a
+    // device the payload omits keeps its stored source instead of
+    // falling back to Homey weather — or restarting at all, when the
+    // store disables it.
+    const sources = this.outdoorSources
     await Promise.all(
       this.#melcloudDevices
-        .filter(({ id }) => outdoorSources[id] !== DISABLED_SOURCE)
+        .filter(({ id }) => sources[id] !== DISABLED_SOURCE)
         .map(async (device) =>
-          this.#listenToDevice(device, outdoorSources[device.id] ?? null),
+          this.#listenToDevice(device, sources[device.id] ?? null),
         ),
     )
   }

--- a/app.mts
+++ b/app.mts
@@ -162,7 +162,7 @@ export default class MELCloudExtensionApp extends App {
     }
     await Promise.all(
       this.#melcloudDevices
-        .filter(({ id }) => (outdoorSources[id] ?? null) !== DISABLED_SOURCE)
+        .filter(({ id }) => outdoorSources[id] !== DISABLED_SOURCE)
         .map(async (device) =>
           this.#listenToDevice(device, outdoorSources[device.id] ?? null),
         ),
@@ -308,6 +308,7 @@ export default class MELCloudExtensionApp extends App {
   #inheritedSource(
     device: HomeyAPIV3Local.ManagerDevices.Device,
     stored: OutdoorSources,
+    homeyIdByMelcloudId: ReadonlyMap<string, string>,
   ): string | null {
     const melcloudId = toJoinKey(device.data.id)
     const group =
@@ -316,7 +317,6 @@ export default class MELCloudExtensionApp extends App {
         : this.#deviceGroups?.find(({ deviceIds }) =>
             deviceIds.includes(melcloudId),
           )
-    const homeyIdByMelcloudId = this.#getHomeyIdByMelcloudId()
     const siblingSources = new Set(
       (group?.deviceIds ?? [])
         .filter((id) => id !== melcloudId)
@@ -329,7 +329,7 @@ export default class MELCloudExtensionApp extends App {
     if (siblingSources.size !== 1) {
       return DISABLED_SOURCE
     }
-    const [shared = DISABLED_SOURCE] = siblingSources
+    const [shared = null] = siblingSources
     return shared
   }
 
@@ -440,10 +440,11 @@ export default class MELCloudExtensionApp extends App {
     )
     const isLegacySeed =
       this.homey.settings.get('hasSeededOutdoorSources') !== true
+    const homeyIdByMelcloudId = this.#getHomeyIdByMelcloudId()
     for (const device of newcomers) {
       stored[device.id] = isLegacySeed
         ? null
-        : this.#inheritedSource(device, stored)
+        : this.#inheritedSource(device, stored, homeyIdByMelcloudId)
     }
     if (newcomers.length > 0) {
       this.outdoorSources = stored

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -837,10 +837,11 @@ const config: Config[] = defineConfig([
       'unicorn/expiring-todo-comments': 'error',
       'unicorn/no-empty-file': 'error',
       'unicorn/no-invalid-file-input-accept': 'error',
-      // The referenced module bundle is a gitignored build output (CI
-      // lints without building); its existence is guaranteed harder by
+      // The referenced module bundle is a gitignored build output (the
+      // lint job never builds); its existence is guaranteed harder by
       // scripts/bundle.mts, which hashes every local reference and
-      // throws when one is missing.
+      // throws when one is missing — exercised on every PR by
+      // validate.yml, whose publish-level validation runs the CLI build.
       'unicorn/no-missing-local-resource': 'off',
       'unicorn/text-encoding-identifier-case': 'error',
     },

--- a/homey-api-override.d.ts
+++ b/homey-api-override.d.ts
@@ -2,10 +2,7 @@ declare module 'homey-api' {
   export class HomeyAPIV3Local {
     readonly devices: HomeyAPIV3Local.ManagerDevices
 
-    static createAppAPI(options: {
-      homey: Homey
-      debug?: ((...args: unknown[]) => void) | null
-    }): Promise<HomeyAPIV3Local>
+    static createAppAPI(options: { homey: Homey }): Promise<HomeyAPIV3Local>
 
     call(options: { method: string; path: string }): Promise<unknown>
   }
@@ -63,8 +60,6 @@ declare module 'homey-api' {
 
   export namespace HomeyAPIV3Local.ManagerDevices.Device {
     export class DeviceCapability {
-      readonly value: boolean | number | string | null
-
       destroy(): void
 
       setValue(value: boolean | number | string): Promise<void>

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -88,9 +88,9 @@ fieldset[disabled] button:disabled {
 
 /* Thin chevron at the field's end, matching the Homey select */
 .combobox::after {
+  block-size: 0.5em;
   border-block-end: 0.15em solid currentColor;
   border-inline-end: 0.15em solid currentColor;
-  block-size: 0.5em;
   content: '';
   inline-size: 0.5em;
   inset-block-start: 50%;
@@ -114,11 +114,11 @@ fieldset[disabled] button:disabled {
   background: var(--homey-color-component, #fff);
   border-radius: 1em;
   box-shadow: 0 0.5em 2em rgb(0 0 0 / 20%);
+  font: inherit;
   inset-block-start: calc(100% + 0.25em);
   inset-inline: 0;
   list-style: none;
   margin: 0;
-  font: inherit;
   max-block-size: 16em;
   overflow: auto;
   padding: 0.5em 0;

--- a/tests/fixtures/webview-hashes/valid.json
+++ b/tests/fixtures/webview-hashes/valid.json
@@ -1,5 +1,1 @@
-{
-  "ata-group-setting": "aaaa1111",
-  "charts": "cccc3333",
-  "settings": "bbbb2222"
-}
+{ "page-a": "aaaa1111", "page-b": "bbbb2222", "page-c": "cccc3333" }

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -22,7 +22,6 @@ export const names: Names = {
 export interface MockCapabilityInstance {
   readonly destroy: ReturnType<typeof vi.fn>
   readonly setValue: ReturnType<typeof vi.fn>
-  value: StoredCapabilityValue
   readonly listener: (value: CapabilityValue) => Promise<void> | void
 }
 
@@ -84,11 +83,9 @@ export const createMockDevice = ({
         setValue: vi
           .fn<(value: CapabilityValue) => Promise<void>>()
           .mockImplementation(async (value) => {
-            instance.value = value
             values[capabilityId] = value
             await Promise.resolve()
           }),
-        value: values[capabilityId] ?? null,
       }
       capabilityInstances.set(capabilityId, instance)
       return instance
@@ -98,7 +95,6 @@ export const createMockDevice = ({
 }
 
 export interface MockDevicesManager {
-  readonly connect: ReturnType<typeof vi.fn>
   readonly eventHandlers: Map<string, (...args: unknown[]) => void>
   readonly getCapabilityValue: ReturnType<typeof vi.fn>
   readonly getDevice: ReturnType<typeof vi.fn>
@@ -152,14 +148,7 @@ export const createMockDevicesManager = (
       eventHandlers.set(event, callback)
     },
   })
-  return {
-    connect,
-    eventHandlers,
-    getCapabilityValue,
-    getDevice,
-    getDevices,
-    manager,
-  }
+  return { eventHandlers, getCapabilityValue, getDevice, getDevices, manager }
 }
 
 export interface MockHomey {
@@ -168,10 +157,8 @@ export interface MockHomey {
   readonly eventHandlers: Map<string, (...args: unknown[]) => void>
   readonly homey: Homey.Homey
   readonly realtime: ReturnType<typeof vi.fn>
-  readonly setSetting: ReturnType<typeof vi.fn>
   readonly settingsStore: Partial<HomeySettings>
   readonly translate: ReturnType<typeof vi.fn>
-  readonly unsetSetting: ReturnType<typeof vi.fn>
 }
 
 export const createMockHomey = ({
@@ -241,9 +228,7 @@ export const createMockHomey = ({
     eventHandlers,
     homey,
     realtime,
-    setSetting,
     settingsStore,
     translate,
-    unsetSetting,
   }
 }

--- a/tests/unit/api-route-guards.test.ts
+++ b/tests/unit/api-route-guards.test.ts
@@ -79,8 +79,8 @@ const extractPathTemplates = (source: string): string[] =>
 
 // The typed helpers carry the verb in their name; the boot beacon calls
 // the raw SDK with the verb as its first argument. Reading the pair
-// matters because eleven declared paths differ only by method —
-// `/classic/sessions` alone is declared under POST, GET and DELETE. The
+// matters because a surface may declare one path under several
+// methods, so a path alone cannot identify its route. The
 // helper name must be followed immediately by its generic or its paren,
 // so the import list is not read as a call site. Template-built paths
 // are swept separately below; a path passed as a variable stays out of
@@ -108,9 +108,9 @@ const extractRouteCalls = (source: string): DeclaredRoute[] => {
   ]
 }
 
-// Every PUT and DELETE call site builds its path from a template, so the
-// literal sweeps above see none of them — the verbs carrying the whole
-// settings surface would go unchecked. A template is still partly known
+// A call site may build its path from a template, which the literal
+// sweeps above cannot see — left alone, such verbs would go
+// unchecked. A template is still partly known
 // at build time: its literal chunks are fixed and ordered, and only the
 // `${…}` holes float (one may expand to nothing, as an optional query
 // string does). Keeping the chunks and letting the holes float is enough
@@ -126,13 +126,13 @@ const escapeRegExp = (chunk: string): string =>
 // literal chunks are found by tracking depth, not by a regex that would
 // stop at the first inner `}`. `${` is folded to one sentinel first so
 // the scan reads a single character per step.
-const HOLE = ''
+const HOLE = '\u{1}'
 
 const toTemplateChunks = (template: string): string[] => {
   const chunks: string[] = []
   let literal = ''
   let depth = 0
-  for (const char of template.replaceAll('${', '')) {
+  for (const char of template.replaceAll('${', '\u{1}')) {
     if (char === HOLE) {
       if (depth === 0) {
         chunks.push(literal)

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -53,7 +53,6 @@ const createHomeyContext = ({
   const homey = mock<Homey>({
     app: mock<MELCloudExtensionApp>({
       autoAdjustCooling,
-      deviceGroups,
       error: vi.fn<(...args: readonly unknown[]) => void>(),
       homey: {
         settings: {
@@ -308,9 +307,14 @@ describe('api', () => {
 
   describe('webview hashes', () => {
     it('should serve the packaged manifest map', async () => {
+      const { homey } = createHomeyContext({
+        melcloudDevices: [],
+        temperatureSensors: [],
+      })
+
       // A dev suite run packages no manifest: the empty map is the
       // documented fresh-by-default answer.
-      await expect(api.getWebviewHashes()).resolves.toStrictEqual({})
+      await expect(api.getWebviewHashes({ homey })).resolves.toStrictEqual({})
     })
   })
 })

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -604,6 +604,45 @@ describe(MELCloudExtensionApp, () => {
     })
   })
 
+  it('should not restart a device the payload omits but the store disables', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    classicDevice.values.thermostat_mode = 'cool'
+    homeDevice.values.thermostat_mode = 'cool'
+    const { app } = await createHarness([classicDevice, homeDevice], {
+      settings: { outdoorSources: { 'classic-1': 'none' } },
+    })
+
+    await advancePastInit()
+    await app.autoAdjustCooling({
+      isEnabled: true,
+      outdoorSources: { 'home-1': null },
+    })
+
+    expect(classicDevice.capabilityInstances.size).toBe(0)
+    expect(homeDevice.capabilityInstances.has('target_temperature')).toBe(true)
+  })
+
+  it('should route an omitted device through its stored source', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    classicDevice.values.thermostat_mode = 'cool'
+    homeDevice.values.thermostat_mode = 'cool'
+    const { app } = await createHarness([classicDevice, homeDevice], {
+      settings: {
+        outdoorSources: { 'home-1': 'classic-1:measure_temperature.outdoor' },
+      },
+    })
+
+    await advancePastInit()
+    await app.autoAdjustCooling({
+      isEnabled: true,
+      outdoorSources: { 'classic-1': null },
+    })
+
+    expect(
+      classicDevice.capabilityInstances.has('measure_temperature.outdoor'),
+    ).toBe(true)
+  })
+
   it('should log instead of crashing when the debounced reload fails', async () => {
     const { classicDevice } = createDevices()
     const { app, manager } = await createHarness([classicDevice])

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -2,7 +2,7 @@ import type * as HomeyApi from 'homey-api'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HomeyLib from '../../lib/homey.mts'
-import type { TimestampedLog } from '../../types.mts'
+import type { HomeySettings, TimestampedLog } from '../../types.mts'
 import { changelog } from '../../files.mts'
 import { assertDefined, cast } from '../helpers.ts'
 import {
@@ -94,10 +94,7 @@ const createHarness = async (
     settings = {},
     version = '0.0.0',
   }: {
-    readonly settings?: Parameters<typeof createMockHomey>[0] extends
-      { settings?: infer TSettings } | undefined
-      ? TSettings
-      : never
+    readonly settings?: Partial<HomeySettings>
     readonly version?: string
   } = {},
 ): Promise<Harness> => {
@@ -274,14 +271,14 @@ describe(MELCloudExtensionApp, () => {
     await advancePastInit()
 
     mockHomey.apiAppGet.mockReturnValue([
-      { deviceIds: ['classic-1'], name: 'Nouvelle maison' },
+      { deviceIds: ['1000'], name: 'Nouvelle maison' },
     ])
 
     await expect(app.refreshDeviceGroups()).resolves.toStrictEqual([
-      { deviceIds: ['classic-1'], name: 'Nouvelle maison' },
+      { deviceIds: ['1000'], name: 'Nouvelle maison' },
     ])
     expect(app.deviceGroups).toStrictEqual([
-      { deviceIds: ['classic-1'], name: 'Nouvelle maison' },
+      { deviceIds: ['1000'], name: 'Nouvelle maison' },
     ])
   })
 

--- a/tests/unit/capability-source.test.ts
+++ b/tests/unit/capability-source.test.ts
@@ -266,7 +266,7 @@ describe(CapabilityOutdoorSource, () => {
     expect(source.value).toBe(26)
   })
 
-  it('should clear the subscribers on destroy', async () => {
+  it('should tear down the capability instance on destroy', async () => {
     const harness = createHarness()
     const source = await CapabilityOutdoorSource.create(
       harness.app,

--- a/tests/unit/melcloud-listener.test.ts
+++ b/tests/unit/melcloud-listener.test.ts
@@ -198,7 +198,7 @@ describe(MELCloudListener, () => {
     ).toHaveBeenCalledWith(31)
   })
 
-  it('should treat a missing outdoor reading as the default temperature', async () => {
+  it('should fall back to the stored threshold when the outdoor reading is missing', async () => {
     const harness = createHarness({
       outdoorTemperature: null,
       targetTemperature: 17,

--- a/tests/unit/webview-hashes.test.ts
+++ b/tests/unit/webview-hashes.test.ts
@@ -17,9 +17,9 @@ describe(getWebviewHashes, () => {
     await expect(
       getWebviewHashes(fixture('valid.json')),
     ).resolves.toStrictEqual({
-      'ata-group-setting': 'aaaa1111',
-      charts: 'cccc3333',
-      settings: 'bbbb2222',
+      'page-a': 'aaaa1111',
+      'page-b': 'bbbb2222',
+      'page-c': 'cccc3333',
     })
   })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { type ViteUserConfig, defineConfig } from 'vitest/config'
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
-      exclude: ['scripts/**/*.mts', 'settings/**/*.mts'],
+      exclude: ['.homeybuild/**', 'scripts/**/*.mts', 'settings/**/*.mts'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
Round-2 residue wave for this app — every finding personally re-verified against the tree before action.

## Corrigé (18)

- **homey-api-override.d.ts** : `DeviceCapability.value` et l'option `debug?` de `createAppAPI` supprimés — plus aucun lecteur (le seul consommateur de `.value`, `isCooling`, est parti au rond 1 ; `createAppAPI` n'est appelé qu'avec `{ homey }`).
- **tests/mocks.ts** : le champ `value` du double d'instance (écrit, jamais lu), et les expositions `connect` / `setSetting` / `unsetSetting` (les implémentations restent câblées dans les doubles ; seules les clés retournées, qu'aucun test ne lit, tombent).
- **api.mts** : breadcrumbs `logSettingsRoute` sur `/webview-hashes` (première route appelée par la page) et `/cooling/auto-adjustment` (écriture terminale) — la séquence de diagnostic couvre désormais ses deux extrémités ; `logWebviewBoot` reste délibérément sans breadcrumb (il logge déjà via `app.error`). Les deux handlers voisins accèdent à `app` de la même façon.
- **app.mts** : la map Homey↔MELCloud est construite une fois par réconciliation et passée à `#inheritedSource` (elle était reconstruite par newcomer) ; le `?? null` sans effet du filtre (celui de la ligne suivante, porteur, reste) ; le défaut de déstructuration inatteignable dit `null` au lieu d'impliquer un repli `DISABLED_SOURCE`.
- **tests** : deux noms de tests réalignés sur le comportement épinglé (le « default temperature » n'existe plus ; le test destroy observe le teardown de l'instance, pas les subscribers) ; la fixture de rename `/devices/groups` parle en ids MELCloud (`1000`), conformément à la doctrine de jointure ; la propriété `deviceGroups` morte du mock app d'api.test.ts ; le type conditionnel `infer` ×5 lignes remplacé par `Partial<HomeySettings>` nommé plainement.
- **eslint.config.ts** : la raison du ledger `unicorn/no-missing-local-resource` nomme désormais où la garantie atterrit en CI — validate.yml, dont la validation publish déclenche le build CLI (vérifié : le `readFile` de `hashOf` rejette hors du try/catch de `stampHtml` → build en échec sur ressource manquante).
- **.prettierignore** : reçoit les deux moitiés stale-tree (`settings/index.js`/`index.mjs`) avec le commentaire d'intention d'eslint — prettier tourne en local, où les restes existent. `sonar-project.properties` n'en a délibérément PAS besoin : Sonar analyse un clone propre en CI, où les fichiers gitignorés n'existent pas (le retrait du rond 1 était correct).
- **vitest.config.ts** : `.homeybuild/**` exclu de la couverture (le glob `**/*.mts` ramassait les `.d.mts` du build dans le lcov envoyé à Sonar).
- **settings/styles.css** : les deux blocs non triés réalignés sur l'ordre alphabétique du reste de la feuille.
- Retouches jumelles (préparées en amont de cette vague, ×3 dépôts) : commentaires du kernel route-guards neutralisés, fixture webview-hashes neutre (`page-a/b/c`), roster de jumeaux complété dans CLAUDE.md.

## Réfuté / écarté

- Roster CLAUDE.md et fixture sibling (trouvailles #6/#7) : déjà couverts par les retouches jumelles ci-dessus.
- L'asymétrie sonar/prettierignore telle que rapportée : l'état réel post-rond-1 était l'inverse (les deux fichiers ne listaient plus rien) ; la moitié prettier est réelle et corrigée, la moitié Sonar est un non-besoin (clone CI propre) — voir ci-dessus.

## Différé avec raison

- Le hazard latent de `#seedOutdoorSources` (l'objet `stored` muté passé à `#inheritedSource`) : les deux branches ont été tracées, l'issue est stable aujourd'hui (le premier newcomer d'un bâtiment neuf retombe toujours sur `DISABLED_SOURCE`) — à revisiter si l'héritage change.
- Les éléments pesés et écartés par la review elle-même (beacon padding, wrappers getElement, boîtes d'état mono-champ, `lastLogs` non-readonly) ne sont pas rouverts.

## Notes de coordination jumeaux (pour la boucle de merge)

- Prettier (objectWrap collapse) replie `tests/fixtures/webview-hashes/valid.json` en une ligne — les trois dépôts convergent vers la même forme, identité octale à revérifier au merge.
- `unicorn/prefer-unicode-code-point-escapes` impose la forme `'\u{1}'` (code point escape) pour le sentinelle du kernel route-guards — autofix appliqué ici, même forme attendue dans les deux dépôts frères.

Suite complète verte : format 0, lint 0, typecheck 0, 203 tests / couverture 100 % (branches incluses), homey:validate publish OK (aucune réécriture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
