### PR TITLE
chore: format the README and follow the tsdk setting rename

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,3 @@
 /.homeycompose/app.json
 /app.json
 /locales/
-/README.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
+  "js/ts.tsdk.path": "node_modules/@typescript/native",
   "sonarlint.connectedMode.project": {
     "connectionId": "olivierzal",
     "projectKey": "OlivierZal_com.melcloud.extension"
-  },
-  "typescript.native-preview.tsdk": "node_modules/@typescript/native"
+  }
 }


### PR DESCRIPTION
Config-ghost sweep follow-ups, same as the sibling PRs: `/README.md` leaves `.prettierignore` (already prettier-clean, zero diff; the entry only hid future drift), and `.vscode/settings.json` follows the extension's announced rename `typescript.native-preview.tsdk` → `js/ts.tsdk.path` (same value, key re-sorted). Audited and kept: `/env.json` (secrets-class guard), `scripts/**` Sonar exclusions and `**/*.jpg` (both real here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3