### PR TITLE
fix: let the freeze dim outweigh the injected cascade

### DIFF
--- a/settings/styles.css
+++ b/settings/styles.css
@@ -39,7 +39,11 @@ fieldset.busy-scope {
    reaches form controls — the combobox list's items are plain `li`
    elements, and a list opened before a keyboard-activated request
    would otherwise stay clickable while frozen. */
-fieldset[disabled] {
+/* The `body` ancestor outweighs the injected sheet's `all: unset` on
+   its reset fieldsets whatever the order: without it the section dim
+   can lose the cascade on-device, and the button neutralizer below then
+   leaves in-flight buttons fully opaque. */
+body fieldset[disabled] {
   cursor: not-allowed;
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
Sibling hardening of com.melcloud's observed regression (OlivierZal/com.melcloud#1529): the `fieldset[disabled]` dim tied (0,1,1) with the injected sheet's fieldset resets, so injection order decided whether a frozen section dimmed — and the button neutralizer counts on that container dim. The `body` ancestor lifts the rule to (0,1,2), order-proof. Latent here (not reported), same mechanism. The `busy-scope` display rule stays: this app never toggles `hidden` on a fieldset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3