### PR TITLE
feat: poke open webviews with the freshness handshake at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,10 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   document from the HTTP cache; sessionStorage guard,
   `webview-freshness.mts`), whose fresh stamps pull the fresh assets;
   a mismatch that survives its refetch is reported to
-  `POST /boot-error`. Every failure
+  `POST /boot-error`. The app also emits a `webview_hashes_changed`
+  realtime event at its own boot; an open page re-runs the same
+  handshake on it — a second trigger of the one primitive, covering a
+  page left open across an app restart or update. Every failure
   path stays open: an unstamped page, an absent route or denied
   storage must never take a working webview down.
   When the bundle still fails to boot, the `onHomeyReady` poll's timeout
@@ -367,8 +370,10 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   before acting either way. Resolve the thread once settled; none left
   dangling.
 - SonarCloud must be spotless for a PR to merge: quality gate green,
-  zero open issues on its analysis, and 100 % coverage (within the
-  exclusions `sonar-project.properties` declares). A Sonar finding is
+  zero open issues on its analysis, 100 % coverage (within the
+  exclusions `sonar-project.properties` declares), and 0 % duplicated
+  lines across the WHOLE codebase — new and old alike, not just the
+  gate's new-code window. A Sonar finding is
   handled like a lint error — the code adapts, or the divergence is
   settled as a documented verdict — never merged over.
 - Homey App Store releases: write the user-facing changelog entry into

--- a/app.mts
+++ b/app.mts
@@ -134,6 +134,9 @@ export default class MELCloudExtensionApp extends App {
       })
     })
     this.#createNotification()
+    // Poke any open webview to re-run its freshness handshake: an app
+    // (re)boot is exactly when the served hashes may have moved.
+    this.homey.api.realtime('webview_hashes_changed', null)
   }
 
   public override async onUninit(): Promise<void> {

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -788,29 +788,43 @@ const reportInitFailure = (homey: Homey, error: unknown): void => {
  * overlay is still up never gets seen.
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
+// One freshness pass, shared by the boot pull and the app's realtime
+// poke; its breadcrumbs ride the declared boot-error route.
+const checkFreshness = async (homey: Homey): Promise<boolean> =>
+  ensureFreshWebview(
+    'settings',
+    async () => homeyApiGet(homey, '/webview-hashes'),
+    (message) => {
+      homey.api(
+        'POST',
+        '/boot-error',
+        { message, name: 'WebviewFreshness' },
+        () => {
+          // A missed freshness breadcrumb is acceptable.
+        },
+      )
+    },
+  )
+
+// Boot pull, then push subscription: a stale page refetches itself
+// (the caller skips its init — the document is about to be replaced);
+// a fresh one subscribes to the app's boot poke and re-runs the same
+// handshake when it fires.
+const startFreshness = async (homey: Homey): Promise<boolean> => {
+  if (await checkFreshness(homey)) {
+    return true
+  }
+  homey.on('webview_hashes_changed', () => {
+    fireAndForget(checkFreshness(homey))
+  })
+  return false
+}
+
 export const start = async (homey: Homey): Promise<void> => {
   // Listeners before the data load: the Refresh button is the retry
   // affordance when the initial load fails or times out, so it must work
   // regardless of how `run` ends.
-  // A stale cached page refetches itself once (never-cached address)
-  // instead of booting: skip
-  // the init — the document is about to be replaced.
-  if (
-    await ensureFreshWebview(
-      'settings',
-      async () => homeyApiGet(homey, '/webview-hashes'),
-      (message) => {
-        homey.api(
-          'POST',
-          '/boot-error',
-          { message, name: 'WebviewFreshness' },
-          () => {
-            // A missed freshness breadcrumb is acceptable.
-          },
-        )
-      },
-    )
-  ) {
+  if (await startFreshness(homey)) {
     return
   }
   addEventListeners(homey)

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -137,6 +137,18 @@ describe(MELCloudExtensionApp, () => {
     expect(app.deviceGroups).toStrictEqual(groups)
   })
 
+  it('should poke open webviews with the freshness event at boot', async () => {
+    const { classicDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice])
+
+    await advancePastInit()
+
+    expect(mockHomey.realtime).toHaveBeenCalledWith(
+      'webview_hashes_changed',
+      null,
+    )
+  })
+
   it('should stamp the legacy weather default on the first seeding', async () => {
     const { classicDevice } = createDevices()
     const { mockHomey } = await createHarness([classicDevice])
@@ -700,9 +712,9 @@ describe(MELCloudExtensionApp, () => {
     app.pushToUI('cleanedAll')
     app.pushToUI('error.notFound', { idOrName: 'x', type: 'Device' })
 
-    const [firstLog] = mockHomey.realtime.mock.calls.map(
-      ([, log]) => log as TimestampedLog,
-    )
+    const [firstLog] = mockHomey.realtime.mock.calls
+      .filter(([event]) => event === 'log')
+      .map(([, log]) => log as TimestampedLog)
 
     expect(firstLog?.category).toBe('cleanedAll')
     expect(firstLog?.message).toBe('log.cleanedAll')


### PR DESCRIPTION
Second trigger of the freshness primitive, approved design: the app emits `webview_hashes_changed` (realtime, no payload — the route stays the single source of truth) once at init, and an open settings page re-runs the exact same `ensureFreshWebview` call it used at boot (one shared `checkFreshness`, Sonar whole-code duplication stays 0 %). Covers the scenario the boot pull cannot: a page left open across an app restart or update — the dev-loop case. What it does not cover (by design): a page opened later boots through the already-merged pull trigger; a page cached before the handshake existed remains reachable by neither (one-time purge or natural eviction). The per-identity sessionStorage guard needs no change: a fresh page is never marked, so the first pushed mismatch refetches. Subscription form: `homey.on('webview_hashes_changed', …)` — the settings-SDK precedent this app's log stream already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3