### PR TITLE
fix: let the busy-scope chrome reset outweigh the injected cascade

### DIFF
--- a/settings/styles.css
+++ b/settings/styles.css
@@ -24,7 +24,11 @@ button:disabled {
    per-building control with one `disabled` flip while a request is in
    flight: no UA fieldset chrome may surface. Explicit `display: block`
    because WebKit renders inline fieldsets atomically. */
-fieldset.busy-scope {
+/* The `body` ancestor outweighs the injected sheet's fieldset styling
+   whatever the order — the same device as the disabled-dim rule; the
+   sibling app's panel frames survived a (0,1,1) tie on-device. This
+   app never hides a busy-scope fieldset, so `display` stays here. */
+body fieldset.busy-scope {
   border: 0;
   display: block;
   margin: 0;


### PR DESCRIPTION
Sibling hardening of OlivierZal/com.melcloud#1531: the `fieldset.busy-scope` chrome reset was the one freeze rule left at (0,1,1) — an on-device tie against the injected sheet, proven in com.melcloud on a fresh page (its two body-prefixed siblings are live-confirmed fixed, so cache is excluded). Latent here, same `body`-ancestor remedy; `display` stays in the rule since this app never hides a busy-scope fieldset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3