### PR TITLE
docs: clear the session residue from comments and doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,9 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   refetch of the document through a never-cached address
   (`?fresh=<identity>` — a bare reload can be re-served the same stale
   document from the HTTP cache; sessionStorage guard,
-  `webview-freshness.mts`), whose fresh stamps pull the fresh assets;
+  `webview-freshness.mts` — byte-identical in the three apps, its test
+  differing only by its import path; edit all three together), whose
+  fresh stamps pull the fresh assets;
   a mismatch that survives its refetch is reported to
   `POST /boot-error`. The app also emits a `webview_hashes_changed`
   realtime event at its own boot; an open page re-runs the same
@@ -217,7 +219,7 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   `fieldsetElements`. Its
   `serialize` must stay a PURE form snapshot, never a request-body
   builder, and disabled greying styles `button:disabled` generically,
-  never a per-class list. `tests/dirty-gate.test.ts` locks the behavior;
+  never a per-class list. `tests/unit/dirty-gate.test.ts` locks the behavior;
   the module is a byte-identical copy of com.melcloud's
   `public/dirty-gate.mts` (com.heatzy carries the third copy) — edit all
   three together.

--- a/api.mts
+++ b/api.mts
@@ -98,7 +98,8 @@ const api = {
   },
   /**
    * Serves the packaged webview-bundle hashes so a booted page can
-   * detect a stale cached copy of itself and reload once.
+   * detect a stale cached copy of itself and refetch once through a
+   * never-cached address.
    * @param options - Homey API context.
    * @param options.homey - Homey instance carrying the app.
    * @returns The bundle hash per page entry; empty outside the

--- a/app.mts
+++ b/app.mts
@@ -428,11 +428,6 @@ export default class MELCloudExtensionApp extends App {
     )
   }
 
-  // Every known AC device gets an EXPLICIT outdoor-source entry, so a
-  // device appearing later is distinguishable from one whose entry was
-  // never written. The first seeding on an existing install stamps the
-  // legacy default (null = Homey weather) and changes nothing;
-  // afterwards newcomers go through #inheritedSource.
   // Brings the per-device source entries in line with the freshly
   // loaded device set: the legacy single-source form migrates first so
   // seeding sees its result, and newcomers start disabled (opt-in).
@@ -441,6 +436,11 @@ export default class MELCloudExtensionApp extends App {
     this.#seedOutdoorSources()
   }
 
+  // Every known AC device gets an EXPLICIT outdoor-source entry, so a
+  // device appearing later is distinguishable from one whose entry was
+  // never written. The first seeding on an existing install stamps the
+  // legacy default (null = Homey weather) and changes nothing;
+  // afterwards newcomers go through #inheritedSource.
   #seedOutdoorSources(): void {
     const stored: OutdoorSources = this.outdoorSources
     const newcomers = this.#melcloudDevices.filter(

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -808,8 +808,9 @@ const checkFreshness = async (homey: Homey): Promise<boolean> =>
 
 // Boot pull, then push subscription: a stale page refetches itself
 // (the caller skips its init — the document is about to be replaced);
-// a fresh one subscribes to the app's boot poke and re-runs the same
-// handshake when it fires.
+// any page that stays — fresh, or stale but unable to refetch —
+// subscribes to the app's boot poke and re-runs the same handshake
+// when it fires.
 const startFreshness = async (homey: Homey): Promise<boolean> => {
   if (await checkFreshness(homey)) {
     return true

--- a/settings/styles.css
+++ b/settings/styles.css
@@ -22,12 +22,11 @@ button:disabled {
 
 /* The sources container is a fieldset so the dirty gate can freeze every
    per-building control with one `disabled` flip while a request is in
-   flight: no UA fieldset chrome may surface. Explicit `display: block`
-   because WebKit renders inline fieldsets atomically. */
-/* The `body` ancestor outweighs the injected sheet's fieldset styling
-   whatever the order — the same device as the disabled-dim rule; the
-   sibling app's panel frames survived a (0,1,1) tie on-device. This
-   app never hides a busy-scope fieldset, so `display` stays here. */
+   flight: no UA fieldset chrome may surface, and the `body` ancestor
+   keeps this reset above the injected sheet's fieldset styling whatever
+   the stylesheet order. Explicit `display: block` because WebKit renders
+   inline fieldsets atomically — it may live here only while no
+   busy-scope fieldset is ever `hidden`, which it would defeat. */
 body fieldset.busy-scope {
   border: 0;
   display: block;
@@ -37,16 +36,14 @@ body fieldset.busy-scope {
 }
 
 /* A dirty-gate freeze sets `disabled` on the gated fieldset while its
-   request is in flight — grey it like the buttons. Attribute (not
-   `:disabled`) so nested fieldsets inside a frozen section do not
-   compound the opacity; `pointer-events` because `disabled` only
-   reaches form controls — the combobox list's items are plain `li`
-   elements, and a list opened before a keyboard-activated request
-   would otherwise stay clickable while frozen. */
-/* The `body` ancestor outweighs the injected sheet's `all: unset` on
-   its reset fieldsets whatever the order: without it the section dim
-   can lose the cascade on-device, and the button neutralizer below then
-   leaves in-flight buttons fully opaque. */
+   request is in flight — grey it like the buttons; the `body` ancestor
+   keeps the dim above the injected sheet's fieldset resets whatever the
+   stylesheet order, and the button neutralizer below counts on it.
+   Attribute (not `:disabled`) so nested fieldsets inside a frozen
+   section do not compound the opacity; `pointer-events` because
+   `disabled` only reaches form controls — the combobox list's items are
+   plain `li` elements, and a list opened before a keyboard-activated
+   request would otherwise stay clickable while frozen. */
 body fieldset[disabled] {
   cursor: not-allowed;
   opacity: 0.5;


### PR DESCRIPTION
Session cleanup review before the releases — comments and doctrine only, no behavior change:

- **settings/styles.css**: the two `body`-prefixed rules carried STACKED comments narrating the sibling app's on-device episode; merged into single constraint statements. The busy-scope one now states the real limit its `display: block` imposes (no busy-scope fieldset may ever be `hidden` — the block display would defeat it), instead of referencing the sibling's split.
- **settings/index.mts**: mirrors the subscription comment wording the sibling review settled (OlivierZal/com.heatzy#1080 thread) — any page that stays subscribes, not only a fresh one; `ensureFreshWebview` also returns `false` for stale-but-unable-to-refetch.
- **api.mts**: the `getWebviewHashes` JSDoc still said “reload once” — pre-refetch vocabulary.
- **CLAUDE.md**: `tests/dirty-gate.test.ts` → `tests/unit/dirty-gate.test.ts` (real path), and the freshness paragraph now declares `webview-freshness.mts` byte-identical ×3 (test differing only by its import path), matching the roster pattern of the other twins.
- **app.mts**: #1253's member re-sort left `#seedOutdoorSources`'s doc block stacked on `#reconcileSourceEntries`; re-attached to its method.

Verified and clean, no action: the autoAdjustCooling restart fix and its two tests (no overlap with the store-merge test), the mocks internals (`connect`/`setSetting`/`unsetSetting` stay load-bearing inside the doubles), the ignore/sonar files (no ghosts; `scripts/` exists), the `#seedOutdoorSources` latent-hazard trace (still order-stable after the session's `[shared = null]` and map hoist), and the freshness twins (module md5-identical ×3, test identical below its import line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3