### PR TITLE
chore(release): 25.2.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -415,5 +415,20 @@
     "pl": "Zapisanie ustawień chłodzenia nie usuwa już źródła temperatury zewnętrznej urządzeń, które nie były widoczne na stronie.",
     "ru": "Сохранение настроек охлаждения больше не стирает источник наружной температуры устройств, которые не отображались на странице.",
     "sv": "När du sparar dina kylinställningar rensas inte längre källan för utetemperatur för enheter som inte visades på sidan."
+  },
+  "25.2.0": {
+    "ar": "تتحدّث صفحة الإعدادات الآن تلقائيًا بعد تحديث التطبيق، ويُجمَّد النموذج أثناء تطبيق تغييراتك، وتحتفظ الأجهزة غير المشمولة بتحديث إعدادات التبريد بمصدر درجة الحرارة الخارجية عند إعادة تشغيل الضبط.",
+    "da": "Indstillingssiden opdaterer nu sig selv efter en app-opdatering, formularen er låst, mens dine ændringer anvendes, og enheder, der ikke indgik i en opdatering af køleindstillingerne, beholder deres udetemperatur-kilde, når justeringen genstarter.",
+    "de": "Die Einstellungsseite aktualisiert sich nach einem App-Update jetzt von selbst, das Formular ist gesperrt, während deine Änderungen angewendet werden, und Geräte, die von einer Aktualisierung der Kühleinstellungen nicht erfasst waren, behalten beim Neustart der Anpassung ihre Außentemperatur-Quelle.",
+    "en": "The settings page now refreshes itself after an app update, the form is locked while your changes are being applied, and devices left out of a cooling settings update keep their outdoor temperature source when adjustment restarts.",
+    "es": "La página de ajustes ahora se actualiza sola tras una actualización de la app, el formulario queda bloqueado mientras se aplican tus cambios, y los dispositivos no incluidos en una actualización de los ajustes de refrigeración conservan su fuente de temperatura exterior al reiniciarse el ajuste.",
+    "fr": "La page de réglages se met désormais à jour d'elle-même après une mise à jour de l'app, le formulaire est figé pendant l'application de vos changements, et les appareils absents d'une mise à jour des réglages de refroidissement conservent leur source de température extérieure au redémarrage de l'ajustement.",
+    "it": "La pagina delle impostazioni ora si aggiorna da sola dopo un aggiornamento dell'app, il modulo è bloccato mentre le modifiche vengono applicate, e i dispositivi esclusi da un aggiornamento delle impostazioni di raffreddamento mantengono la loro fonte della temperatura esterna al riavvio della regolazione.",
+    "ko": "이제 앱 업데이트 후 설정 페이지가 자동으로 새로 고쳐지고, 변경 사항이 적용되는 동안 양식이 잠기며, 냉방 설정 업데이트에 포함되지 않은 기기는 조정이 다시 시작될 때 외기 온도 소스를 유지합니다.",
+    "nl": "De instellingenpagina vernieuwt zichzelf nu na een app-update, het formulier is vergrendeld terwijl je wijzigingen worden toegepast, en apparaten die buiten een update van de koelinstellingen vielen, behouden hun buitentemperatuurbron wanneer de aanpassing herstart.",
+    "no": "Innstillingssiden oppdaterer nå seg selv etter en app-oppdatering, skjemaet er låst mens endringene dine tas i bruk, og enheter som ikke var med i en oppdatering av kjøleinnstillingene, beholder utetemperatur-kilden når justeringen starter på nytt.",
+    "pl": "Strona ustawień odświeża się teraz sama po aktualizacji aplikacji, formularz jest zablokowany podczas zapisywania zmian, a urządzenia pominięte w aktualizacji ustawień chłodzenia zachowują swoje źródło temperatury zewnętrznej przy ponownym uruchomieniu regulacji.",
+    "ru": "Страница настроек теперь обновляется сама после обновления приложения, форма блокируется на время применения изменений, а устройства, не вошедшие в обновление настроек охлаждения, сохраняют источник наружной температуры при перезапуске регулировки.",
+    "sv": "Inställningssidan uppdaterar nu sig själv efter en appuppdatering, formuläret är låst medan dina ändringar tillämpas, och enheter som inte ingick i en uppdatering av kylinställningarna behåller sin källa för utetemperatur när justeringen startar om."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -198,5 +198,5 @@
       "värmepump"
     ]
   },
-  "version": "25.1.1"
+  "version": "25.2.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,11 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   SECURITY.md, CLAUDE.md) — never a later sweep; the 2026-08 README
   audit caught exactly the drift this prevents (a shipped Home ATW
   driver absent from its README, a stale `Result` kind list).
+- Every substantive wave ends with a cleanup pass over its own diff —
+  residue (history comments, orphaned helpers, stale doc claims),
+  simplification, and the factoring the change just made possible.
+  Features land first, the sweep runs second, so the sweep covers
+  them; a wave is not done until that pass has run.
 
 - Design phases (on Olivier's call, start and end): iterate on
   `design/*` branches with dev-installs only — no PR merges, no tags,

--- a/app.json
+++ b/app.json
@@ -199,5 +199,5 @@
       "värmepump"
     ]
   },
-  "version": "25.1.1"
+  "version": "25.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.1.1",
+  "version": "25.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "25.1.1",
+      "version": "25.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "homey-api": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.1.1",
+  "version": "25.2.0",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
App Store release of the session's arc, everything on-device-validated: the freshness handshake with its realtime second trigger (the settings page reconciles itself after an app update — one imperfect transition for pages cached before the mechanism, self-healing ever after), the dirty-gate freeze over the form while a request is in flight, and the cooling-adjustment restart routed from the merged source map (devices left out of a partial update keep their stored source; a disabled one no longer restarts). Store-facing changelog entry under the new `25.2.0` key, 13 locales. Also lands the post-wave cleanup-pass doctrine bullet (Olivier's rule: features first, sweep second, a wave is not done until its own diff had the pass). Merge, then tag `v25.2.0` and publish the GitHub release to fire `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3