### PR TITLE
refactor: vote newcomer sources over the pre-seed snapshot

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -448,17 +448,31 @@ export default class MELCloudExtensionApp extends App {
     )
     const isLegacySeed =
       this.homey.settings.get('hasSeededOutdoorSources') !== true
-    const homeyIdByMelcloudId = this.#getHomeyIdByMelcloudId()
-    for (const device of newcomers) {
-      stored[device.id] = isLegacySeed
-        ? null
-        : this.#inheritedSource(device, stored, homeyIdByMelcloudId)
-    }
+    this.#writeNewcomerEntries(stored, newcomers, isLegacySeed)
     if (newcomers.length > 0) {
       this.outdoorSources = stored
     }
     if (isLegacySeed) {
       this.homey.settings.set('hasSeededOutdoorSources', true)
+    }
+  }
+
+  // The sibling vote reads a pre-seed snapshot, never the map being
+  // written: only entries that predate this reconciliation — user
+  // decisions and past seeds — may decide a newcomer, so one
+  // newcomer's inferred value cannot leak into another's vote. The
+  // first (legacy) seed stamps the historical default instead.
+  #writeNewcomerEntries(
+    stored: OutdoorSources,
+    newcomers: readonly HomeyAPIV3Local.ManagerDevices.Device[],
+    isLegacySeed: boolean,
+  ): void {
+    const homeyIdByMelcloudId = this.#getHomeyIdByMelcloudId()
+    const decided: OutdoorSources = { ...stored }
+    for (const device of newcomers) {
+      stored[device.id] = isLegacySeed
+        ? null
+        : this.#inheritedSource(device, decided, homeyIdByMelcloudId)
     }
   }
 }

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -191,6 +191,25 @@ describe(MELCloudExtensionApp, () => {
     })
   })
 
+  it('should start both newcomers of a fresh building disabled', async () => {
+    const { classicDevice, homeDevice } = createDevices()
+    const { mockHomey } = await createHarness([classicDevice, homeDevice], {
+      settings: { hasSeededOutdoorSources: true, outdoorSources: {} },
+    })
+    mockHomey.apiAppGet.mockReturnValue([
+      { deviceIds: ['1000', 'uuid-home-1'], name: 'Domicile' },
+    ])
+
+    await advancePastInit()
+
+    // The sibling vote reads only pre-seed entries: neither newcomer
+    // may count the other's freshly inferred value as a decision.
+    expect(mockHomey.settingsStore.outdoorSources).toStrictEqual({
+      'classic-1': 'none',
+      'home-1': 'none',
+    })
+  })
+
   it('should default a newcomer to disabled when no grouping is available', async () => {
     const { classicDevice, homeDevice } = createDevices()
     const { mockHomey } = await createHarness([classicDevice, homeDevice], {


### PR DESCRIPTION
Settles the latent `#seedOutdoorSources` hazard the round-2 review traced and parked. Cold re-trace on current code (post map-hoist, post restart-fix): the mutating read is still provably order-independent — an inferred entry can only ever equal the group's unanimous configured value or `none`, and adding either to a later unanimity vote cannot change its outcome — but that proof is an invariant of the CURRENT rule, and any future change to the inheritance rule (majority vote, cross-group sources, per-iteration edits of decided entries) would break it silently. The hardening makes the invariant structural instead of algebraic: the vote reads a pre-seed snapshot (`decided`) inside the extracted `#writeNewcomerEntries` (the `max-statements` cap forced the extraction, which reads better anyway), the loop writes `stored`, and the constraint comment says why. No behavior change today (proven by the trace; the full suite agrees); a new test pins the fresh-building contract — two newcomers joining a virgin group both start disabled, neither counting the other's inference as a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3