### PR TITLE
refactor: adopt the exclusive-arming gate contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,11 +215,13 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   fieldsets while a request is in flight (container `disabled` +
   `aria-busy`, so a control's own domain `disabled` survives the thaw):
   every success path rewrites the fields, so a mid-flight edit would be
-  silently clobbered — pass every region `serialize` reads through
-  `fieldsetElements`. Its
-  `serialize` must stay a PURE form snapshot, never a request-body
-  builder, and disabled greying styles `button:disabled` generically,
-  never a per-class list. `tests/unit/dirty-gate.test.ts` locks the behavior;
+  silently clobbered — pass every region the arming source reads through
+  `fieldsetElements`. Arming comes from exactly ONE source, exclusive by
+  type: baseline mode (`serialize`, a pure snapshot — never a
+  request-body builder) or predicate mode (`isActionable`, no baseline
+  at all; `markSaved` then only re-evaluates) — this app's single pair
+  is baseline-mode. Disabled greying styles `button:disabled`
+  generically, never a per-class list. `tests/unit/dirty-gate.test.ts` locks the behavior;
   the module is a byte-identical copy of com.melcloud's
   `public/dirty-gate.mts` (com.heatzy carries the third copy) — edit all
   three together.

--- a/settings/dirty-gate.mts
+++ b/settings/dirty-gate.mts
@@ -76,8 +76,11 @@ const setFrozen = (
   }
 }
 
-// The gate evaluates its arming at creation, so Apply starts greyed even
-// when no data ever loads; call `markSaved` after every (re)populate and
+// The gate evaluates its arming at creation: in baseline mode Apply
+// starts greyed even when no data ever loads (the form matches its own
+// snapshot), in predicate mode it starts wherever `isActionable` puts
+// it — a prefilled form may legitimately arm at once. Call `markSaved`
+// after every (re)populate and
 // successful save (in predicate mode it only re-evaluates — there is no
 // baseline to move), `recompute` after any programmatic field write (no
 // `input` event fires for those), `wire` on the controls the arming

--- a/settings/dirty-gate.mts
+++ b/settings/dirty-gate.mts
@@ -1,11 +1,12 @@
 // The webviews' shared dirty-gating primitive: one gate owns one Apply
-// button — greyed while the form matches its saved baseline OR a request
+// button — greyed while the form is not worth submitting OR a request
 // is in flight — its sibling Refresh buttons, greyed by busy alone so
 // they stay the escape hatch on a pristine form, and the form's
 // fieldsets, frozen by busy alone: every success path rewrites the
 // fields, so an edit slipped in mid-flight would be silently clobbered
 // when the response lands — the freeze closes that window. The factory
-// owns the whole invariant; a call site only supplies `serialize`.
+// owns the whole invariant; a call site only supplies its arming source
+// (a pure snapshot or a domain predicate, exclusively).
 // Byte-identical copies of this module live in the sibling Homey apps —
 // edit them together.
 
@@ -17,17 +18,39 @@ export interface DirtyGate {
   readonly wire: (targets: readonly EventTarget[]) => void
 }
 
-export interface DirtyGateOptions {
+// Arming comes from exactly ONE source. Baseline mode: `serialize` is a
+// PURE snapshot of the form's current values — never a request-body
+// builder: those filter defaults and null deltas out, which desyncs the
+// pristine check — and Apply arms when the snapshot diverges from the
+// saved baseline. Predicate mode: when the wire protocol cannot express
+// every form divergence (an emptied field means "no instruction" and is
+// omitted from the request), supply `isActionable` instead — Apply arms
+// only when pressing it would send something, and no baseline exists to
+// retain stale form state. The pair is exclusive by type: a predicate
+// site has no use for a baseline (the predicate would short-circuit it
+// into dead weight).
+export type DirtyGateOptions = {
   readonly applyElement: HTMLButtonElement
   readonly fieldsetElements?: readonly HTMLFieldSetElement[]
   readonly refreshElements?: readonly HTMLButtonElement[]
-  readonly serialize: () => string
-  readonly isActionable?: () => boolean
-}
+} & (
+  | { readonly isActionable?: undefined; readonly serialize: () => string }
+  | { readonly serialize?: undefined; readonly isActionable: () => boolean }
+)
+
+// Predicate mode consults the domain judgment; baseline mode diffs the
+// pure snapshot against the saved baseline.
+const isArmed = (
+  options: DirtyGateOptions,
+  saved: string | undefined,
+): boolean =>
+  options.isActionable === undefined
+    ? options.serialize() !== saved
+    : options.isActionable()
 
 // `input` covers live typing in number/date fields; `change` covers the
-// selects and the final commit (and, since `serialize` reads the whole
-// form, any field a cascade handler mutated).
+// selects and the final commit (and, since the arming source reads the
+// whole form, any field a cascade handler mutated).
 const wireRecompute = (
   targets: readonly EventTarget[],
   recompute: () => void,
@@ -53,40 +76,30 @@ const setFrozen = (
   }
 }
 
-// `serialize` must be a PURE snapshot of the form's current values — never
-// a request-body builder: those filter defaults and null deltas out, which
-// desyncs the pristine check. The gate snapshots it at creation, so Apply
-// starts greyed even when no data ever loads; call `markSaved` after every
-// (re)populate and successful save, `wire` on the controls the snapshot
-// reads, and route every request through `runBusy`. When the wire
-// protocol cannot express every form divergence (an emptied field means
-// "no instruction" and is omitted from the request), supply
-// `isActionable`: Apply then arms only when pressing it would send
-// something — the arming predicate gains domain judgment while the
-// baseline bookkeeping stays the pure snapshot. Buttons grey through
-// native `disabled` (not a CSS class): it blocks keyboard activation
-// during in-flight actions and is announced by screen readers.
-export const createDirtyGate = ({
-  applyElement,
-  fieldsetElements = [],
-  isActionable,
-  refreshElements = [],
-  serialize,
-}: DirtyGateOptions): DirtyGate => {
+// The gate evaluates its arming at creation, so Apply starts greyed even
+// when no data ever loads; call `markSaved` after every (re)populate and
+// successful save (in predicate mode it only re-evaluates — there is no
+// baseline to move), `recompute` after any programmatic field write (no
+// `input` event fires for those), `wire` on the controls the arming
+// source reads, and route every request through `runBusy`. Buttons grey
+// through native `disabled` (not a CSS class): it blocks keyboard
+// activation during in-flight actions and is announced by screen
+// readers.
+export const createDirtyGate = (options: DirtyGateOptions): DirtyGate => {
+  const { applyElement, fieldsetElements = [], refreshElements = [] } = options
   let busyGeneration = 0
   let isBusy = false
-  let saved = serialize()
+  let saved = options.serialize?.()
   const recompute = (): void => {
-    applyElement.disabled =
-      isBusy || !(isActionable?.() ?? serialize() !== saved)
+    applyElement.disabled = isBusy || !isArmed(options, saved)
   }
   const markSaved = (): void => {
-    saved = serialize()
+    saved = options.serialize?.()
     recompute()
   }
   // Refresh is gated by busy ALONE (never dirty); Apply folds the busy
-  // flag into its dirty check so a mid-request edit cannot re-enable it;
-  // the fieldsets freeze and thaw with it (`setFrozen`).
+  // flag into its arming check so a mid-request edit cannot re-enable
+  // it; the fieldsets freeze and thaw with it (`setFrozen`).
   const setBusy = (isBusyNow: boolean): void => {
     isBusy = isBusyNow
     for (const element of refreshElements) {
@@ -109,9 +122,14 @@ export const createDirtyGate = ({
       }
     }
   }
-  const wire = (targets: readonly EventTarget[]): void => {
-    wireRecompute(targets, recompute)
-  }
   recompute()
-  return { markSaved, recompute, runBusy, setBusy, wire }
+  return {
+    markSaved,
+    recompute,
+    runBusy,
+    setBusy,
+    wire: (targets: readonly EventTarget[]): void => {
+      wireRecompute(targets, recompute)
+    },
+  }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -28,7 +28,7 @@
                         // fails on this device.
                         const script = document.querySelector('script[src*="index.js"]')
                         const report = (probe) => {
-                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, stack: '', userAgent: navigator.userAgent }, () => {})
+                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent }, () => {})
                             homey.ready()
                             homey.alert(homey.__('settings.loadFailed')).catch(() => {})
                         }

--- a/tests/unit/dirty-gate.test.ts
+++ b/tests/unit/dirty-gate.test.ts
@@ -123,18 +123,15 @@ describe('dirty gate', () => {
     expect(refreshElement.disabled).toBe(false)
   })
 
-  it('should arm Apply through isActionable instead of the snapshot diff', () => {
+  it('should arm Apply through isActionable with no baseline at all', () => {
     const applyElement = mock<HTMLButtonElement>({ disabled: false })
     const actionable = { value: false }
-    const form = { value: 'pristine' }
+    // Predicate mode carries NO serialize: the gate must construct and
+    // recompute without ever reaching for a snapshot.
     const gate = createDirtyGate({
       applyElement,
       isActionable: () => actionable.value,
-      serialize: () => form.value,
     })
-
-    form.value = 'edited'
-    gate.recompute()
 
     expect(applyElement.disabled).toBe(true)
 
@@ -144,6 +141,25 @@ describe('dirty gate', () => {
     expect(applyElement.disabled).toBe(false)
 
     gate.setBusy(true)
+
+    expect(applyElement.disabled).toBe(true)
+  })
+
+  it('should degrade markSaved to a re-evaluation in predicate mode', () => {
+    const applyElement = mock<HTMLButtonElement>({ disabled: false })
+    const actionable = { value: true }
+    const gate = createDirtyGate({
+      applyElement,
+      isActionable: () => actionable.value,
+    })
+
+    expect(applyElement.disabled).toBe(false)
+
+    // A successful save typically drains the predicate (the form now
+    // matches the persisted state); markSaved must pick that up even
+    // though it has no baseline to move.
+    actionable.value = false
+    gate.markSaved()
 
     expect(applyElement.disabled).toBe(true)
   })


### PR DESCRIPTION
Final twin chantier of wave B, part 3 of 3 — byte-identical propagation of OlivierZal/com.melcloud#1541 (module + test, import line aside). Site verdict here: the app's single Update/Refresh pair is baseline-mode (`serialize: serializeState`) — behavior unchanged, its `markSaved` sites stay meaningful baselines. Diagnostics: the inline boot beacon already carried `name: 'BootTimeout'`; its hard-coded `stack: ''` is dropped (the handler takes `body: unknown` and keeps accepting cached pages — not hardened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3