### PR TITLE
build: adopt configs 1.2.1

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
     with:
       coverage-node-version: '22'
 name: CI

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -13,11 +13,13 @@ jobs:
       actions: read
       contents: read
       id-token: write
+      packages: read
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
     with:
+      repo-guidance: 'The app ids `com.mecloud` and `com.mecloud.extension` carry a load-bearing historical typo — never "correct" the spelling anywhere (manifest, code, docs or links).'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`, and `npm run homey:validate`'
 name: Claude Dependabot Fix
 on:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@c498c9308d041f8df580293edd0f39df255198e0 # v1.2.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@3242d565365a1c7943f454ea74d40c95bfe49283 # v1.2.1
 name: zizmor
 on:
   merge_group: {}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,10 +11,6 @@ const config: Config[] = defineConfig([
       'lib/**/*.mts',
       'listeners/**/*.mts',
     ],
-    // No drivers, so no untyped SDK doubles — but the preset requires a
-    // non-empty glob (ESLint rejects `files: []`), so this one matches
-    // nothing by design.
-    untypedDoubleTestFiles: ['tests/none/**'],
     webviewFloorFiles: ['settings/**/*.mts'],
   }),
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.2.0",
+        "@olivierzal/configs": "1.2.1",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.1",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.2.0/930506e9ef448f19dd6102328de8bd084c8d1536",
-      "integrity": "sha512-06Y4mpPoePILTM+ROmwiERPlNJQyyKrpisoLZwWm9DhYyGQ1iGSy7TmaDXTCLCt+LXfepRhG2j2PXoElNhzwQA==",
+      "version": "1.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.2.1/7e651d38b234aa3d4b884729b295506b1da87358",
+      "integrity": "sha512-xYOtdvKcO+WU9tm6lv5fpsyxeqRi/p/FhbuVONb9JkdqxIa8vP/efU333EAKOpXe7TK4i+ij5hg462r3JmSw4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.2.0",
+    "@olivierzal/configs": "1.2.1",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.1",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Exact-pin bump 1.2.0 → 1.2.1 and stub SHA bump to `3242d565 # v1.2.1` (×9). Rides the 1.2.1 fixes: the `tests/none/**` no-match workaround is gone (`untypedDoubleTestFiles` now defaults to `[]` — `--print-config` diff on a real test file is empty, proving the cleanup is behavior-neutral), the dependabot-fix stub grants `packages: read` to match the callable's new declaration, and passes a `repo-guidance` warning the automated fixer about the load-bearing `com.mecloud` typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3