### PR TITLE
build: adopt @olivierzal/homey-kit 2.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,13 +157,22 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   refetch of the document through a never-cached address
   (`?fresh=<identity>` — a bare reload can be re-served the same stale
   document from the HTTP cache; sessionStorage guard,
-  `ensureFreshWebview` from `@olivierzal/homey-kit/webview`), whose
+  `watchWebviewFreshness` from `@olivierzal/homey-kit/webview`), whose
   fresh stamps pull the fresh assets;
   a mismatch that survives its refetch is reported to
-  `POST /boot-error`. The app also emits a `webview_hashes_changed`
-  realtime event at its own boot; an open page re-runs the same
-  handshake on it — a second trigger of the one primitive, covering a
-  page left open across an app restart or update. Every failure
+  `POST /boot-error`. The guarantee lives in the BOOT check, and which
+  surface needs it was measured on device (2026-08-07): the web-app
+  settings page is destroyed and REMOUNTED when the app restarts, and
+  mobile widgets reload too — both are fresh for free. Only the mobile
+  settings page survives an app restart, so it alone never boots again;
+  that is why the watcher re-checks on RETURN TO THE FOREGROUND
+  (`visibilitychange`), the trigger that covers it. The app also emits a
+  `webview_hashes_changed` realtime event at its own boot and the page
+  subscribes to it, but it guarantees NOTHING on its own: it fires at
+  the end of the app's `onInit`, i.e. exactly when the restart has just
+  disconnected every open page, so its audience is absent by
+  construction (measured: an open mobile page produced no request and no
+  breadcrumb). Never fold the visibility trigger into it. Every failure
   path stays open: an unstamped page, an absent route or denied
   storage must never take a working webview down.
   When the bundle still fails to boot, the `onHomeyReady` poll's timeout
@@ -328,7 +337,7 @@ need auth.
 manifest reader runs on the device) owns what used to be copied across
 the three apps: the dirty gate and the freshness handshake
 (`/webview`), the settings transport (`/settings`), the manifest reader
-(`/node`), `fireAndForget`/`getErrorMessage`/`NotFoundError`
+(`/node`), `fireAndForget`/`getErrorMessage`
 (root) and the two test kernels (`/testing`). A change to any of them
 is a kit release adopted here by a pin bump — never a local edit, and
 never a re-derivation.
@@ -339,6 +348,14 @@ What stays local, by measurement rather than omission:
   the dev tools, it does not log through a logger instance. The kit's
   node-side seam takes `(promise, logger, message)` and is what every
   `app.mts`/`listeners/**` site uses.
+- `lib/errors.mts` (`NotFoundError`): unlike the two sibling apps, this
+  one forces `super('notFound')` and `api.mts` throws it with NO
+  argument, because `settings/index.mts` matches on that exact message
+  (`message === 'notFound'`) to tell "no MELCloud device paired yet"
+  from a real failure. Swapping in the kit's class — whose message is
+  whatever the caller passes — would silently break that branch, and no
+  test would see it. Extend the kit class or keep this one; never
+  replace it blind.
 - The `ManagerSettings` augmentation: the local block is STRICTER than
   the kit's generic (no `(key: string) => unknown` overload) and carries
   `unset`, which the generic lacks. Adopting it would loosen this app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "25.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/homey-kit": "1.1.0",
+        "@olivierzal/homey-kit": "2.1.0",
         "homey-api": "^3.19.1",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/@olivierzal/homey-kit": {
-      "version": "1.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/1.1.0/e955bdc2cc4ee522d5e0c653cdb8815406793203",
-      "integrity": "sha512-E40JaceAkOoAC6emYifRCgQW803kymWS0C6KvrCd1ksSwKoER8WioGeFYVe4FFclQ8BR2lqJOGu/+B7bFrK+3Q==",
+      "version": "2.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/2.1.0/59976d3544764f9ea1126a75baeffc381fdbba85",
+      "integrity": "sha512-2QVRVeV1ChvEaRf1tTMW9udC4B2UwTttByB4SuTNKwZ6+IkJsfY0g44je34lzmBu/Btm1pq+KhlXnkUvsRiA9A==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "25.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/homey-kit": "2.1.0",
+        "@olivierzal/homey-kit": "2.1.1",
         "homey-api": "^3.19.1",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/@olivierzal/homey-kit": {
-      "version": "2.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/2.1.0/59976d3544764f9ea1126a75baeffc381fdbba85",
-      "integrity": "sha512-2QVRVeV1ChvEaRf1tTMW9udC4B2UwTttByB4SuTNKwZ6+IkJsfY0g44je34lzmBu/Btm1pq+KhlXnkUvsRiA9A==",
+      "version": "2.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/2.1.1/f94bf5ce9b5521b0e82e877d5f6efb1f1dfad7f4",
+      "integrity": "sha512-6NG0mD+QiZchYKQZVhcUtCrqEuHthjsQH8mDmKCBbu6rEG6BW++cI0P5sFfmFc1PgV8xZyl0aMxAPZ3zRUf16A==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/homey-kit": "2.1.0",
+    "@olivierzal/homey-kit": "2.1.1",
     "homey-api": "^3.19.1",
     "temporal-polyfill": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/homey-kit": "1.1.0",
+    "@olivierzal/homey-kit": "2.1.0",
     "homey-api": "^3.19.1",
     "temporal-polyfill": "^1.0.1"
   },

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -7,7 +7,7 @@ import {
 } from '@olivierzal/homey-kit/settings'
 import {
   createDirtyGate,
-  ensureFreshWebview,
+  watchWebviewFreshness,
 } from '@olivierzal/homey-kit/webview'
 import { Temporal } from 'temporal-polyfill'
 
@@ -794,13 +794,15 @@ const reportInitFailure = (homey: Homey, error: unknown): void => {
  * overlay is still up never gets seen.
  * @param homey - The Homey instance handed to `onHomeyReady`.
  */
-// One freshness pass, shared by the boot pull and the app's realtime
-// poke; its breadcrumbs ride the declared boot-error route.
-const checkFreshness = async (homey: Homey): Promise<boolean> =>
-  ensureFreshWebview(
-    'settings',
-    async () => homeyApiGet(homey, '/webview-hashes'),
-    (message) => {
+// Boot check plus the triggers that cover a page outliving it: this
+// webview survives an app restart on mobile, so no new document — and
+// no boot check — ever happens there. Breadcrumbs ride the declared
+// boot-error route.
+const startFreshness = async (homey: Homey): Promise<boolean> =>
+  watchWebviewFreshness({
+    entry: 'settings',
+    fetchHashes: async () => homeyApiGet(homey, '/webview-hashes'),
+    report: (message) => {
       homey.api(
         'POST',
         '/boot-error',
@@ -810,22 +812,10 @@ const checkFreshness = async (homey: Homey): Promise<boolean> =>
         },
       )
     },
-  )
-
-// Boot pull, then push subscription: a stale page refetches itself
-// (the caller skips its init — the document is about to be replaced);
-// any page that stays — fresh, or stale but unable to refetch —
-// subscribes to the app's boot poke and re-runs the same handshake
-// when it fires.
-const startFreshness = async (homey: Homey): Promise<boolean> => {
-  if (await checkFreshness(homey)) {
-    return true
-  }
-  homey.on('webview_hashes_changed', () => {
-    fireAndForget(checkFreshness(homey))
+    subscribe: (onPoke) => {
+      homey.on('webview_hashes_changed', onPoke)
+    },
   })
-  return false
-}
 
 export const start = async (homey: Homey): Promise<void> => {
   // Listeners before the data load: the Refresh button is the retry


### PR DESCRIPTION
Pins `@olivierzal/homey-kit` to 2.1.0 and replaces the hand-wired freshness pair (`ensureFreshWebview` at boot plus a manual `homey.on('webview_hashes_changed', …)`) with the kit's single `watchWebviewFreshness` call, which adds the trigger this page was missing.

**Why the extra trigger** — measured on device 2026-08-07, not assumed: the guarantee lives in the BOOT check, and every surface that rebuilds its page gets it for free. The web-app settings page is destroyed and remounted when the app restarts; mobile widgets reload too. Only the mobile settings page **survives** an app restart, so it never boots again and never re-checks — an open page produced no request and no breadcrumb at all. The realtime poke cannot cover it: the app emits it at the end of its `onInit`, exactly when the restart has just disconnected every open page, so its audience is absent by construction. `watchWebviewFreshness` re-checks on return to the foreground, which is the trigger that fits.

`NotFoundError` stays local here, unlike in the two sibling apps: this one forces `super('notFound')` and `api.mts` throws it with no argument, because `settings/index.mts` matches on that exact message to tell "no MELCloud device paired yet" from a real failure. The verdict is now written in CLAUDE.md so no future dedup pass swaps it blind — and the kit-owned list there is corrected, it wrongly claimed the kit already supplied it.

Bundles rebuilt from `.homeybuild`: `index.js` 67489 → 68034, `index.mjs` 66993 → 67538 (+545 each, the new trigger's runner and breadcrumb dedup). No `node:`/`require(`/`__dirname`, no es2024+ runtime API.

**On-device test before merge** — reproduces the measured scenario exactly:
1. Install this branch, open the settings page **on the phone**, leave it open and put the Homey app in the **background** (do not kill it).
2. Change any bundle byte, `npm run homey:install` — the app restarts with a different stamp.
3. **Return to the foreground**: the page must refresh itself, in a single navigation. Regression = page frozen on the old content.
4. Bound check: background/foreground several times — exactly one navigation in total, no reload loop.
5. Controls (unchanged behaviour expected): cold open → fresh; web app → fresh by remount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
