### PR TITLE
fix: authenticate the publish install against GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,18 @@ jobs:
         with:
           cache: none
           npm-token: ${{ secrets.GITHUB_TOKEN }}
+      # The publish action installs inside a Docker container that mounts
+      # the workspace, not the runner temp where setup-node writes the
+      # registry auth — so the config has to travel with the sources or
+      # the @olivierzal install 401s.
+      - run: cp "$NPM_CONFIG_USERCONFIG" "$GITHUB_WORKSPACE/.npmrc"
       - id: publish
         name: Publish
         uses: athombv/github-action-homey-app-publish@48be66b7f2f870c22b6117d7bb84dfa06c4fc309 # v1
         with:
           personal_access_token: ${{ secrets.HOMEY_PAT }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # The CLI's own `npm run build` (post-copy) must have emitted the
       # settings bundles into .homeybuild and stamped the packaged page —
       # a silent regression here is the com.melcloud #1404 class.

--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -431,7 +431,7 @@
     "ru": "Страница настроек теперь обновляется сама после обновления приложения, форма блокируется на время применения изменений, а устройства, не вошедшие в обновление настроек охлаждения, сохраняют источник наружной температуры при перезапуске регулировки.",
     "sv": "Inställningssidan uppdaterar nu sig själv efter en appuppdatering, formuläret är låst medan dina ändringar tillämpas, och enheter som inte ingick i en uppdatering av kylinställningarna behåller sin källa för utetemperatur när justeringen startar om."
   },
-  "25.2.1": {
+  "25.2.2": {
     "ar": "صفحة الإعدادات المتروكة مفتوحة على هاتفك تتحدّث الآن عند العودة إليها بعد تحديث التطبيق، بدلًا من البقاء على النسخة السابقة.",
     "da": "En indstillingsside, der er ladt åben på din telefon, opdaterer nu sig selv, når du vender tilbage til den efter en app-opdatering, i stedet for at blive stående på den forrige version.",
     "de": "Eine auf deinem Telefon geöffnet gelassene Einstellungsseite aktualisiert sich jetzt selbst, wenn du nach einem App-Update zu ihr zurückkehrst, statt auf der vorherigen Version zu bleiben.",

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -198,5 +198,5 @@
       "värmepump"
     ]
   },
-  "version": "25.2.1"
+  "version": "25.2.2"
 }

--- a/app.json
+++ b/app.json
@@ -199,5 +199,5 @@
       "värmepump"
     ]
   },
-  "version": "25.2.1"
+  "version": "25.2.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.2.1",
+  "version": "25.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "25.2.1",
+      "version": "25.2.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.2.1",
+  "version": "25.2.2",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
The v25.2.1 publish run failed with `401 Unauthorized` fetching `@olivierzal/homey-kit`: the Athom publish action installs inside a Docker container that mounts the workspace, not the runner temp where setup-node writes the registry auth. Both sibling apps already copy the config into the workspace and pass `NODE_AUTH_TOKEN` to the action; this app never needed it until the kit adoption gave it its first scoped production dependency.

Ships as **25.2.2**: 25.2.1 never reached Athom, so its changelog entry moves to the version that will actually ship rather than leaving a store entry for a release that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3