### PR TITLE
build: adopt @olivierzal/homey-kit 3.1.0

### DIFF
--- a/homey-override.d.ts
+++ b/homey-override.d.ts
@@ -1,3 +1,4 @@
+import type { TypedManagerSettings } from '@olivierzal/homey-kit/types'
 import type HomeyLib from 'homey/lib/Homey.js'
 
 import type MELCloudExtensionApp from './app.mts'
@@ -9,13 +10,13 @@ declare module 'homey' {
     settings: ManagerSettings
   }
 
+  // The SDK interfaces are extended, not replaced: the kit generics
+  // supply the narrowed member SIGNATURES, the base supplies everything
+  // else. Extending both directly conflicts on the members they share.
   interface ManagerSettings extends HomeyLib.ManagerSettings {
-    get: <T extends keyof HomeySettings>(key: T) => HomeySettings[T]
-    set: <T extends keyof HomeySettings>(
-      key: T,
-      value: HomeySettings[T],
-    ) => void
-    unset: (key: keyof HomeySettings) => void
+    get: TypedManagerSettings<HomeySettings>['get']
+    set: TypedManagerSettings<HomeySettings>['set']
+    unset: TypedManagerSettings<HomeySettings>['unset']
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "25.2.3",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@olivierzal/homey-kit": "2.2.0",
+        "@olivierzal/homey-kit": "3.1.0",
         "homey-api": "^3.19.1",
         "temporal-polyfill": "^1.0.1"
       },
@@ -1108,9 +1108,9 @@
       }
     },
     "node_modules/@olivierzal/homey-kit": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/2.2.0/27059a7c757b5152fcb7842c7c04b4be04175356",
-      "integrity": "sha512-4fDzbvhx0LJ0C6mr44KLb4DgqAwUe/ymRq0QvSENREr1l+cFEdIGTGA7GlbbiT39MU8ZIM77WbkegCsVRK1xhg==",
+      "version": "3.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/homey-kit/3.1.0/43507d99a6540eba5154e9412317ea8648314e94",
+      "integrity": "sha512-yPeGHtzF33dMODL6p5uqIgsrUCgSiueeVtt3KXA1tDlnvqy2K/Z3tpJfhAWzll5xpWCOuaGsHtmm0pIAu79Q+w==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "prettier": "@olivierzal/configs/prettier",
   "dependencies": {
-    "@olivierzal/homey-kit": "2.2.0",
+    "@olivierzal/homey-kit": "3.1.0",
     "homey-api": "^3.19.1",
     "temporal-polyfill": "^1.0.1"
   },

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -1,12 +1,21 @@
 import type Homey from 'homey/lib/HomeySettings'
 import { getErrorMessage } from '@olivierzal/homey-kit'
 import {
+  getButton,
+  getDetails,
+  getDiv,
+  getFieldset,
+  getSelect,
+} from '@olivierzal/homey-kit/dom'
+import {
   homeyApiGet,
   homeyApiPut,
   homeyCallback,
 } from '@olivierzal/homey-kit/settings'
 import {
   createDirtyGate,
+  fireAndForget,
+  runWebview,
   watchWebviewFreshness,
 } from '@olivierzal/homey-kit/webview'
 import { Temporal } from 'temporal-polyfill'
@@ -21,30 +30,6 @@ import {
   type TimestampedLog,
   DISABLED_SOURCE,
 } from '../types.mts'
-
-// Give slow transports a real chance while keeping the loading overlay
-// finite: past this point the page surfaces the failure instead.
-const INIT_TIMEOUT_MS = 10_000
-
-// Bounds the init chain: `Homey.ready()` must always end the loading
-// overlay, so a hung transport call cannot be allowed to hold it open
-// forever. The underlying work is not cancelled — a late success simply
-// repaints over the degraded state.
-const withInitTimeout = async <T,>(work: Promise<T>): Promise<T> => {
-  let timer: ReturnType<typeof setTimeout> | undefined
-  try {
-    return await Promise.race([
-      work,
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => {
-          reject(new Error('Timed out while loading data from the app'))
-        }, INIT_TIMEOUT_MS)
-      }),
-    ])
-  } finally {
-    clearTimeout(timer)
-  }
-}
 
 const LOG_RETENTION_DAYS = 6
 
@@ -73,76 +58,18 @@ const categories: Partial<Record<string, LogCategory>> = {
  * Surfaces an error in the webview dev tools without blocking the caller:
  * `reportError` where the webview provides it, an async rethrow otherwise.
  */
-const surfaceError = (error: unknown): void => {
-  if (typeof reportError === 'function') {
-    reportError(error)
-    return
-  }
-  setTimeout(() => {
-    throw error instanceof Error
-      ? error
-      : new Error('Unhandled settings error', { cause: error })
-  }, 0)
-}
-
-/**
- * Runs an async operation that shouldn't block. Rejections go to `onError`
- * (default: `surfaceError`, which reports them in the webview dev tools).
- * Distinct from the kit's node-side seam, which logs a context message
- * through a logger instance: a webview has no logger, it surfaces.
- */
-const fireAndForget = (
-  promise: Promise<unknown>,
-  onError: (error: unknown) => void = surfaceError,
-): void => {
-  // eslint-disable-next-line unicorn/prefer-await -- fire-and-forget: rejections surface in the dev tools without blocking the caller
-  promise.catch(onError)
-}
-
-const getElement = <T extends HTMLElement>(
-  id: string,
-  elementConstructor: new () => T,
-  elementType: string,
-): T => {
-  const element = document.querySelector(`#${id}`)
-  // Distinct diagnoses (com.melcloud form): a missing id must not read
-  // as a type mismatch.
-  if (element === null) {
-    throw new TypeError(`Element with id \`${id}\` not found`)
-  }
-  if (!(element instanceof elementConstructor)) {
-    throw new TypeError(`Element with id \`${id}\` is not a ${elementType}`)
-  }
-  return element
-}
-
-const getButtonElement = (id: string): HTMLButtonElement =>
-  getElement(id, HTMLButtonElement, 'button')
-
-const getSelectElement = (id: string): HTMLSelectElement =>
-  getElement(id, HTMLSelectElement, 'select')
-
-const getDivElement = (id: string): HTMLDivElement =>
-  getElement(id, HTMLDivElement, 'div')
-
-const getFieldsetElement = (id: string): HTMLFieldSetElement =>
-  getElement(id, HTMLFieldSetElement, 'fieldset')
-
 // Safe at module load: the bundle is a `defer` classic script, so it runs
 // only after <body> is parsed (see settings/index.html).
-const getDetailsElement = (id: string): HTMLDetailsElement =>
-  getElement(id, HTMLDetailsElement, 'details')
+const applyElement = getButton('apply')
+const adjustmentElement = getFieldset('adjustment')
+const emptyElement = getDiv('empty_state')
+const installElement = getButton('install')
+const refreshElement = getButton('refresh')
+const enabledElement = getSelect('enabled')
+const configurationElement = getDetails('configuration')
 
-const applyElement = getButtonElement('apply')
-const adjustmentElement = getFieldsetElement('adjustment')
-const emptyElement = getDivElement('empty_state')
-const installElement = getButtonElement('install')
-const refreshElement = getButtonElement('refresh')
-const enabledElement = getSelectElement('enabled')
-const configurationElement = getDetailsElement('configuration')
-
-const logsElement = getDivElement('logs')
-const sourcesElement = getFieldsetElement('sources')
+const logsElement = getDiv('logs')
+const sourcesElement = getFieldset('sources')
 
 interface SourceOption {
   readonly name: string
@@ -825,15 +752,11 @@ export const start = async (homey: Homey): Promise<void> => {
     return
   }
   addEventListeners(homey)
-  let initFailure: { readonly cause: unknown } | null = null
-  try {
-    await withInitTimeout(run(homey))
-  } catch (error) {
-    initFailure = { cause: error }
-  } finally {
-    homey.ready()
-  }
-  if (initFailure !== null) {
-    reportInitFailure(homey, initFailure.cause)
+  // Reported AFTER the overlay closes: `runWebview` calls `homey.ready()`
+  // in its `finally` and hands back the outcome, so the failure notice
+  // never competes with the overlay for the screen.
+  const { error, hasFailed } = await runWebview(homey, run(homey))
+  if (hasFailed) {
+    reportInitFailure(homey, error)
   }
 }


### PR DESCRIPTION
Adopts the DOM accessors, the boot cycle and the strict settings types. The manifest readers do not apply here — this app declares no drivers.

## What disappears

| Removed from `settings/index.mts` | Now from |
|---|---|
| `getElement`, `getButtonElement`, `getSelectElement`, `getDivElement`, `getFieldsetElement`, `getDetailsElement` | `@olivierzal/homey-kit/dom` — as `getButton`, `getSelect`, `getDiv`, `getFieldset`, `getDetails` |
| `withInitTimeout`, `surfaceError`, `fireAndForget`, `INIT_TIMEOUT_MS` | `@olivierzal/homey-kit/webview` |

Its local `ManagerSettings` block goes too: the kit generic is now its equal — strict `get`/`set` plus `unset` — so the block that was stricter than the package becomes the package.

112 lines deleted, 36 added.

## What does not change

**The report-after-ready order.** This page notifies the user once the overlay has closed, and that is preserved: `runWebview` calls `homey.ready()` in its `finally` and returns `{ error, hasFailed }`, which the entry point reads. The local `initFailure` bookkeeping was doing the same by hand.

The accessors were already the good form — two diagnoses, absent vs wrong type. Only the names shorten to the family's canonical ones.

## Verified

- Suite green: format, lint, typecheck, 181 tests, build, `homey:validate` at publish level. (It still warns that `homey:manager:api` draws a longer Athom review — unchanged, and unrelated.)
- **Bundle**: `index.js` 67 999 → 68 178 bytes, `index.mjs` 67 503 → 67 682 (+179). No `node:`/`require(`/`__dirname`, no es2024+ API.
- **Real coverage** (exclusions lifted): 54.1 % → **56.8 %** statements, branches 68.2 % → **70.8 %**. 36 statements left for the kit, where they run at 100 %.

## On-device check before merge

Install the branch, then on the **phone**, cold open:

1. Settings page paints in under 10 s, no stuck overlay, no init error.
2. Change a field → Apply arms; undo it → Apply greys again.
3. Press Apply → the fieldsets freeze during the call, then thaw.
4. Leave the page open, background the app, reinstall with a changed bundle, return to the foreground → the page refreshes itself once, and repeated cycles do nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
