### PR TITLE
feat: log the platform split at boot

### DIFF
--- a/app.mts
+++ b/app.mts
@@ -143,6 +143,7 @@ export default class MELCloudExtensionApp extends App {
     // Poke any open webview to re-run its freshness handshake: an app
     // (re)boot is exactly when the served hashes may have moved.
     this.homey.api.realtime('webview_hashes_changed', null)
+    fireAndForget(this.#logBootReady(), this, 'Boot readiness tracking failed:')
   }
 
   public override async onUninit(): Promise<void> {
@@ -408,6 +409,21 @@ export default class MELCloudExtensionApp extends App {
     }
     await this.refreshDeviceGroups()
     this.#reconcileSourceEntries()
+  }
+
+  // Measurement breadcrumb (2026-08): the installed base's platform
+  // split (1 = Homey Pro 2016-2019, 2 = Pro 2023+) decides the node
+  // device-floor policy — read it from diagnostics reports.
+  async #logBootReady(): Promise<void> {
+    await this.homey.ready()
+    this.log(
+      'Boot: ready after',
+      process.uptime().toFixed(1),
+      's — platform',
+      this.homey.platformVersion ?? 'unknown',
+      '— node',
+      process.version,
+    )
   }
 
   // Older versions stored one global outdoor source: seed every known AC

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -196,8 +196,6 @@ export const createMockHomey = ({
   const ready = vi.fn<() => Promise<void>>().mockResolvedValue()
   const homey = mock<Homey.Homey>({
     __: translate,
-    platformVersion,
-    ready,
     api: {
       realtime,
       getApiApp: (): { get: (path: string) => unknown } => ({ get: apiAppGet }),
@@ -205,6 +203,8 @@ export const createMockHomey = ({
     i18n: { getLanguage: (): string => language },
     manifest: { version },
     notifications: { createNotification },
+    platformVersion,
+    ready,
     settings: {
       set: setSetting,
       unset: unsetSetting,

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -156,6 +156,7 @@ export interface MockHomey {
   readonly createNotification: ReturnType<typeof vi.fn>
   readonly eventHandlers: Map<string, (...args: unknown[]) => void>
   readonly homey: Homey.Homey
+  readonly ready: ReturnType<typeof vi.fn>
   readonly realtime: ReturnType<typeof vi.fn>
   readonly settingsStore: Partial<HomeySettings>
   readonly translate: ReturnType<typeof vi.fn>
@@ -163,10 +164,12 @@ export interface MockHomey {
 
 export const createMockHomey = ({
   language = 'en',
+  platformVersion,
   settings = {},
   version = '0.0.0',
 }: {
   readonly language?: string
+  readonly platformVersion?: number | undefined
   readonly settings?: Partial<HomeySettings>
   readonly version?: string
 } = {}): MockHomey => {
@@ -190,8 +193,11 @@ export const createMockHomey = ({
     .mockImplementation((key) => {
       Reflect.deleteProperty(settingsStore, key)
     })
+  const ready = vi.fn<() => Promise<void>>().mockResolvedValue()
   const homey = mock<Homey.Homey>({
     __: translate,
+    platformVersion,
+    ready,
     api: {
       realtime,
       getApiApp: (): { get: (path: string) => unknown } => ({ get: apiAppGet }),
@@ -227,6 +233,7 @@ export const createMockHomey = ({
     createNotification,
     eventHandlers,
     homey,
+    ready,
     realtime,
     settingsStore,
     translate,

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -23,6 +23,8 @@ vi.mock(import('../../lib/homey.mts'), async () => {
   const { mock: mockModule } = await import('../helpers.ts')
   class AppStub {
     public readonly error = vi.fn<(...args: unknown[]) => void>()
+
+    public readonly log = vi.fn<(...args: unknown[]) => void>()
   }
   return mockModule<typeof HomeyLib>({ App: AppStub })
 })
@@ -91,15 +93,22 @@ const createDevices = (): {
 const createHarness = async (
   mockDevices: readonly MockDevice[],
   {
+    bootReadyError,
+    platformVersion,
     settings = {},
     version = '0.0.0',
   }: {
+    readonly bootReadyError?: Error
+    readonly platformVersion?: number | undefined
     readonly settings?: Partial<HomeySettings>
     readonly version?: string
   } = {},
 ): Promise<Harness> => {
   const manager = createMockDevicesManager(mockDevices)
-  const mockHomey = createMockHomey({ settings, version })
+  const mockHomey = createMockHomey({ platformVersion, settings, version })
+  if (bootReadyError) {
+    mockHomey.ready.mockRejectedValueOnce(bootReadyError)
+  }
   const apiCall = createApiCall()
   createAppAPIMock.mockResolvedValue({
     call: apiCall,
@@ -108,6 +117,9 @@ const createHarness = async (
   const app = new MELCloudExtensionApp()
   Object.assign(app, { homey: mockHomey.homey })
   await app.onInit()
+  // The boot-ready breadcrumb is detached (fire-and-forget): flush it.
+  await Promise.resolve()
+  await Promise.resolve()
   return { apiCall, app, manager, mockHomey }
 }
 
@@ -116,6 +128,45 @@ const advancePastInit = async (): Promise<void> => {
 }
 
 describe(MELCloudExtensionApp, () => {
+  it('should log the platform breadcrumb once ready', async () => {
+    const { classicDevice } = createDevices()
+    const { app } = await createHarness([classicDevice], { platformVersion: 2 })
+
+    expect(app.log).toHaveBeenCalledWith(
+      'Boot: ready after',
+      expect.any(String),
+      's — platform',
+      2,
+      '— node',
+      process.version,
+    )
+  })
+
+  it('should fall back to unknown when the platform version is absent', async () => {
+    const { classicDevice } = createDevices()
+    const { app } = await createHarness([classicDevice])
+
+    expect(app.log).toHaveBeenCalledWith(
+      'Boot: ready after',
+      expect.any(String),
+      's — platform',
+      'unknown',
+      '— node',
+      process.version,
+    )
+  })
+
+  it('should log a boot readiness tracking failure', async () => {
+    const { classicDevice } = createDevices()
+    const bootReadyError = new Error('never ready')
+    const { app } = await createHarness([classicDevice], { bootReadyError })
+
+    expect(app.error).toHaveBeenCalledWith(
+      'Boot readiness tracking failed:',
+      bootReadyError,
+    )
+  })
+
   beforeEach(() => {
     vi.useFakeTimers()
   })

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -106,7 +106,7 @@ const createHarness = async (
 ): Promise<Harness> => {
   const manager = createMockDevicesManager(mockDevices)
   const mockHomey = createMockHomey({ platformVersion, settings, version })
-  if (bootReadyError) {
+  if (bootReadyError !== undefined) {
     mockHomey.ready.mockRejectedValueOnce(bootReadyError)
   }
   const apiCall = createApiCall()
@@ -128,6 +128,15 @@ const advancePastInit = async (): Promise<void> => {
 }
 
 describe(MELCloudExtensionApp, () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
   it('should log the platform breadcrumb once ready', async () => {
     const { classicDevice } = createDevices()
     const { app } = await createHarness([classicDevice], { platformVersion: 2 })
@@ -165,15 +174,6 @@ describe(MELCloudExtensionApp, () => {
       'Boot readiness tracking failed:',
       bootReadyError,
     )
-  })
-
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-    vi.clearAllMocks()
   })
 
   it('should expose the building grouping fetched from com.melcloud', async () => {


### PR DESCRIPTION
Measurement breadcrumb mirroring com.melcloud#1556 and com.heatzy#1100: a boot-ready log line carrying `homey.platformVersion` (1 = Homey Pro 2016-2019, 2 = Pro 2023+) and `process.version`, so diagnostics reports show the installed-base split the pending node device-floor decision needs. This app ships no `v`-flag regex (audited), so no parse fix applies here — the line also gives it the boot-readiness mark its siblings already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3