### PR TITLE
chore(release): 25.3.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -778,5 +778,20 @@
     "pl": "Aplikacja nie instaluje już dużego zestawu plików deweloperskich, których nigdy nie potrzebowała, co zwalnia miejsce na Twoim Homey i przy okazji usuwa zgłoszoną lukę w zabezpieczeniach.",
     "ru": "Приложение больше не устанавливает большой набор файлов разработки, которые ему никогда не требовались: это освобождает место на вашем Homey и заодно устраняет обнаруженную уязвимость.",
     "sv": "Appen installerar inte längre en stor mängd utvecklingsfiler som den aldrig behövde, vilket frigör utrymme på din Homey och samtidigt tar bort en rapporterad sårbarhet."
+  },
+  "25.3.0": {
+    "ar": "يتم إعلامك الآن أيضًا بتغييرات الإصدارات التي تخطّيتها.",
+    "da": "Du får nu også besked om ændringerne fra versioner, du sprang over.",
+    "de": "Du wirst jetzt auch über die Änderungen übersprungener Versionen benachrichtigt.",
+    "en": "You are now also notified about the changes from versions you skipped.",
+    "es": "Ahora también se te notifican los cambios de las versiones que te saltaste.",
+    "fr": "Vous êtes désormais aussi notifié des changements des versions que vous avez sautées.",
+    "it": "Ora ricevi notifiche anche per le modifiche delle versioni saltate.",
+    "ko": "이제 건너뛴 버전의 변경 사항도 알림으로 받아볼 수 있습니다.",
+    "nl": "Je krijgt nu ook meldingen over de wijzigingen van overgeslagen versies.",
+    "no": "Du blir nå også varslet om endringene fra versjoner du hoppet over.",
+    "pl": "Otrzymujesz teraz również powiadomienia o zmianach z pominiętych wersji.",
+    "ru": "Теперь вы также получаете уведомления об изменениях в пропущенных версиях.",
+    "sv": "Du meddelas nu även om ändringarna från versioner du hoppat över."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -198,5 +198,5 @@
       "värmepump"
     ]
   },
-  "version": "25.2.3"
+  "version": "25.3.0"
 }

--- a/app.json
+++ b/app.json
@@ -199,5 +199,5 @@
       "värmepump"
     ]
   },
-  "version": "25.2.3"
+  "version": "25.3.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.2.3",
+  "version": "25.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "25.2.3",
+      "version": "25.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.2.3",
+  "version": "25.3.0",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
Store release: skipped-version notifications (with English fallback), the rewritten changelog, and the platform-split measurement breadcrumb. This app never shipped the `v`-flag regexes that broke its siblings on Homey Pro (2016 – 2019) — audited clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3