### PR TITLE
chore(release): 25.3.1

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -779,7 +779,7 @@
     "ru": "Приложение больше не устанавливает большой набор файлов разработки, которые ему никогда не требовались: это освобождает место на вашем Homey и заодно устраняет обнаруженную уязвимость.",
     "sv": "Appen installerar inte längre en stor mängd utvecklingsfiler som den aldrig behövde, vilket frigör utrymme på din Homey och samtidigt tar bort en rapporterad sårbarhet."
   },
-  "25.3.0": {
+  "25.3.1": {
     "ar": "يتم إعلامك الآن أيضًا بتغييرات الإصدارات التي تخطّيتها.",
     "da": "Du får nu også besked om ændringerne fra versioner, du sprang over.",
     "de": "Du wirst jetzt auch über die Änderungen übersprungener Versionen benachrichtigt.",

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -198,5 +198,5 @@
       "värmepump"
     ]
   },
-  "version": "25.3.0"
+  "version": "25.3.1"
 }

--- a/app.json
+++ b/app.json
@@ -199,5 +199,5 @@
       "värmepump"
     ]
   },
-  "version": "25.3.0"
+  "version": "25.3.1"
 }

--- a/app.mts
+++ b/app.mts
@@ -143,7 +143,6 @@ export default class MELCloudExtensionApp extends App {
     // Poke any open webview to re-run its freshness handshake: an app
     // (re)boot is exactly when the served hashes may have moved.
     this.homey.api.realtime('webview_hashes_changed', null)
-    fireAndForget(this.#logBootReady(), this, 'Boot readiness tracking failed:')
   }
 
   public override async onUninit(): Promise<void> {
@@ -409,21 +408,6 @@ export default class MELCloudExtensionApp extends App {
     }
     await this.refreshDeviceGroups()
     this.#reconcileSourceEntries()
-  }
-
-  // Measurement breadcrumb (2026-08): the installed base's platform
-  // split (1 = Homey Pro 2016-2019, 2 = Pro 2023+) decides the node
-  // device-floor policy — read it from diagnostics reports.
-  async #logBootReady(): Promise<void> {
-    await this.homey.ready()
-    this.log(
-      'Boot: ready after',
-      process.uptime().toFixed(1),
-      's — platform',
-      this.homey.platformVersion ?? 'unknown',
-      '— node',
-      process.version,
-    )
   }
 
   // Older versions stored one global outdoor source: seed every known AC

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.3.0",
+  "version": "25.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "25.3.0",
+      "version": "25.3.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.3.0",
+  "version": "25.3.1",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -156,7 +156,6 @@ export interface MockHomey {
   readonly createNotification: ReturnType<typeof vi.fn>
   readonly eventHandlers: Map<string, (...args: unknown[]) => void>
   readonly homey: Homey.Homey
-  readonly ready: ReturnType<typeof vi.fn>
   readonly realtime: ReturnType<typeof vi.fn>
   readonly settingsStore: Partial<HomeySettings>
   readonly translate: ReturnType<typeof vi.fn>
@@ -164,12 +163,10 @@ export interface MockHomey {
 
 export const createMockHomey = ({
   language = 'en',
-  platformVersion,
   settings = {},
   version = '0.0.0',
 }: {
   readonly language?: string
-  readonly platformVersion?: number | undefined
   readonly settings?: Partial<HomeySettings>
   readonly version?: string
 } = {}): MockHomey => {
@@ -193,7 +190,6 @@ export const createMockHomey = ({
     .mockImplementation((key) => {
       Reflect.deleteProperty(settingsStore, key)
     })
-  const ready = vi.fn<() => Promise<void>>().mockResolvedValue()
   const homey = mock<Homey.Homey>({
     __: translate,
     api: {
@@ -203,8 +199,6 @@ export const createMockHomey = ({
     i18n: { getLanguage: (): string => language },
     manifest: { version },
     notifications: { createNotification },
-    platformVersion,
-    ready,
     settings: {
       set: setSetting,
       unset: unsetSetting,
@@ -233,7 +227,6 @@ export const createMockHomey = ({
     createNotification,
     eventHandlers,
     homey,
-    ready,
     realtime,
     settingsStore,
     translate,

--- a/tests/unit/app.test.ts
+++ b/tests/unit/app.test.ts
@@ -93,22 +93,15 @@ const createDevices = (): {
 const createHarness = async (
   mockDevices: readonly MockDevice[],
   {
-    bootReadyError,
-    platformVersion,
     settings = {},
     version = '0.0.0',
   }: {
-    readonly bootReadyError?: Error
-    readonly platformVersion?: number | undefined
     readonly settings?: Partial<HomeySettings>
     readonly version?: string
   } = {},
 ): Promise<Harness> => {
   const manager = createMockDevicesManager(mockDevices)
-  const mockHomey = createMockHomey({ platformVersion, settings, version })
-  if (bootReadyError !== undefined) {
-    mockHomey.ready.mockRejectedValueOnce(bootReadyError)
-  }
+  const mockHomey = createMockHomey({ settings, version })
   const apiCall = createApiCall()
   createAppAPIMock.mockResolvedValue({
     call: apiCall,
@@ -117,9 +110,6 @@ const createHarness = async (
   const app = new MELCloudExtensionApp()
   Object.assign(app, { homey: mockHomey.homey })
   await app.onInit()
-  // The boot-ready breadcrumb is detached (fire-and-forget): flush it.
-  await Promise.resolve()
-  await Promise.resolve()
   return { apiCall, app, manager, mockHomey }
 }
 
@@ -135,45 +125,6 @@ describe(MELCloudExtensionApp, () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
-  })
-
-  it('should log the platform breadcrumb once ready', async () => {
-    const { classicDevice } = createDevices()
-    const { app } = await createHarness([classicDevice], { platformVersion: 2 })
-
-    expect(app.log).toHaveBeenCalledWith(
-      'Boot: ready after',
-      expect.any(String),
-      's — platform',
-      2,
-      '— node',
-      process.version,
-    )
-  })
-
-  it('should fall back to unknown when the platform version is absent', async () => {
-    const { classicDevice } = createDevices()
-    const { app } = await createHarness([classicDevice])
-
-    expect(app.log).toHaveBeenCalledWith(
-      'Boot: ready after',
-      expect.any(String),
-      's — platform',
-      'unknown',
-      '— node',
-      process.version,
-    )
-  })
-
-  it('should log a boot readiness tracking failure', async () => {
-    const { classicDevice } = createDevices()
-    const bootReadyError = new Error('never ready')
-    const { app } = await createHarness([classicDevice], { bootReadyError })
-
-    expect(app.error).toHaveBeenCalledWith(
-      'Boot readiness tracking failed:',
-      bootReadyError,
-    )
   })
 
   it('should expose the building grouping fetched from com.melcloud', async () => {


### PR DESCRIPTION
Final-scope release replacing the never-promoted 25.3.0 (tag kept as an honest trace, changelog entry moved here — this app's line stays the skipped-version notifications, it never had the regex defect). Drops the measurement breadcrumb and its harness additions per the product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3