### PR TITLE
test: bring the settings page and the bundler under the real coverage bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "esbuild": "^0.28.1",
         "eslint": "^10.8.0",
+        "happy-dom": "20.11.2",
         "homey-apps-sdk-v3-types": "^0.3.12",
         "jiti": "^2.7.0",
         "prettier": "^3.9.6",
@@ -1982,6 +1983,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
@@ -3282,6 +3300,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/builtin-modules": {
@@ -4661,6 +4692,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.2.tgz",
+      "integrity": "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/has-binary2": {
@@ -7970,6 +8055,16 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "esbuild": "^0.28.1",
     "eslint": "^10.8.0",
+    "happy-dom": "20.11.2",
     "homey-apps-sdk-v3-types": "^0.3.12",
     "jiti": "^2.7.0",
     "prettier": "^3.9.6",

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -35,6 +35,10 @@ const REFERENCE =
   /(?<prefix>href="|src=")(?<file>[^"':?\/][^"':?]*)(?:\?v=[0-9a-f]+)?(?<suffix>")/gv
 
 const sharedOptions: BuildOptions = {
+  // Pinned at load: esbuild's service process outlives this module and
+  // keeps its own working directory, so relative entries must be
+  // anchored to the app root explicitly.
+  absWorkingDir: process.cwd(),
   bundle: true,
   legalComments: 'none',
   logLevel: 'info',
@@ -78,26 +82,42 @@ const hashOf = async (filePath: string): Promise<string> => {
     .slice(0, HASH_LENGTH)
 }
 
-const collectHashes = async (
+interface StampedReference {
+  readonly hash: string
+  readonly index: number
+  readonly length: number
+  readonly text: string
+}
+
+// Every alternative of `REFERENCE` binds all three named groups with at
+// least one `file` character, so a match always carries them: the empty
+// defaults are the type-level spelling of that invariant, not a runtime
+// path. Hashing runs per reference — the page's references are unique,
+// and re-hashing a small asset is cheaper than a map whose miss no
+// input can reach.
+const collectReferences = async (
   html: string,
   directory: string,
-): Promise<ReadonlyMap<string, string>> => {
-  const files = new Set<string>()
-  for (const match of html.matchAll(REFERENCE)) {
-    const { file = '' } = match.groups ?? {}
-    if (file !== '') {
-      files.add(file)
-    }
-  }
-  return new Map(
-    await Promise.all(
-      [...files].map(async (file): Promise<[string, string]> => [
-        file,
-        await hashOf(path.join(directory, file)),
-      ]),
-    ),
+): Promise<readonly StampedReference[]> =>
+  Promise.all(
+    html
+      .matchAll(REFERENCE)
+      .map(
+        async ({
+          0: { length },
+          groups: { file = '', prefix = '', suffix = '' } = {},
+          index,
+        }): Promise<StampedReference> => {
+          const hash = await hashOf(path.join(directory, file))
+          return {
+            hash,
+            index,
+            length,
+            text: `${prefix}${file}?v=${hash}${suffix}`,
+          }
+        },
+      ),
   )
-}
 
 // Stamp only within a reference context, so the same filename written
 // elsewhere (e.g. a comment) is never rewritten. Rebuilt cursor-wise
@@ -105,17 +125,26 @@ const collectHashes = async (
 // arguments cannot carry the named groups safely.
 const stampReferences = (
   html: string,
-  hashes: ReadonlyMap<string, string>,
+  references: readonly StampedReference[],
 ): string => {
   let stamped = ''
   let cursor = 0
-  for (const match of html.matchAll(REFERENCE)) {
-    const { file = '', prefix = '', suffix = '' } = match.groups ?? {}
-    const hash = hashes.get(file) ?? ''
-    stamped += `${html.slice(cursor, match.index)}${prefix}${file}?v=${hash}${suffix}`
-    cursor = match.index + match[0].length
+  for (const { index, length, text } of references) {
+    stamped += html.slice(cursor, index) + text
+    cursor = index + length
   }
   return stamped + html.slice(cursor)
+}
+
+// The page's identity is the join of its UNIQUE stamp values, in
+// DOCUMENT order — exactly the page's own collection (its
+// `webview-freshness` join dedupes stamps through a Set, so a per-FILE
+// dedupe would diverge on two assets with identical bytes): a change to
+// any packaged asset (bundle, stylesheet) moves the identity, so
+// CSS-only or markup-only ships self-heal too.
+const identityOf = (references: readonly StampedReference[]): string | null => {
+  const stamps = [...new Set(references.map(({ hash }) => hash))]
+  return stamps.length > 0 ? stamps.join('.') : null
 }
 
 const stampHtml = async (htmlPath: string): Promise<string | null> => {
@@ -127,17 +156,12 @@ const stampHtml = async (htmlPath: string): Promise<string | null> => {
     // has nothing to stamp.
     return null
   }
-  const hashes = await collectHashes(html, path.dirname(htmlPath))
-  const stamped = stampReferences(html, hashes)
+  const references = await collectReferences(html, path.dirname(htmlPath))
+  const stamped = stampReferences(html, references)
   if (stamped !== html) {
     await writeFile(htmlPath, stamped)
   }
-  // The page's identity is the join of every stamp it carries, in
-  // DOCUMENT order (the match order of `REFERENCE`, which the page's
-  // own collection mirrors): a change to any packaged asset (bundle,
-  // stylesheet) moves the identity, so CSS-only or markup-only ships
-  // self-heal too.
-  return hashes.size > 0 ? hashes.values().toArray().join('.') : null
+  return identityOf(references)
 }
 
 // Emit the live-hash manifest the app serves (`GET /webview-hashes`) —

--- a/settings/index.mts
+++ b/settings/index.mts
@@ -215,11 +215,10 @@ const displayLog = (log: TimestampedLog): void => {
   const rowElement = createLogRow(log)
   const day = dayOf(log.time)
   if (day === topDay.value) {
-    // Below the day separator sitting on top
-    logsElement.insertBefore(
-      rowElement,
-      logsElement.firstChild?.nextSibling ?? null,
-    )
+    // Below the day separator sitting on top — `item` hands
+    // `insertBefore` its null itself, so no fallback branch dangles on
+    // a pane the separator invariant already guarantees is populated.
+    logsElement.insertBefore(rowElement, logsElement.children.item(1))
     return
   }
   topDay.value = day
@@ -363,9 +362,13 @@ const populateSourceOptions = (
 // can never match a real option, so no checkmark shows either
 const MIXED_SELECTION = '\u{0}'
 
+// Misses stay `undefined` inside the set rather than being defaulted:
+// the seeding invariant (every rendered device is seeded) makes a miss
+// unreachable, and folding it into the sentinel keeps every branch here
+// one a test can exercise (the device-less group covers the empty set).
 const commonSelectionOf = (deviceIds: readonly string[]): string => {
   const values = new Set(
-    deviceIds.map((deviceId) => sourceSelections.get(deviceId) ?? ''),
+    deviceIds.map((deviceId) => sourceSelections.get(deviceId)),
   )
   const [first] = values
   return first !== undefined && values.size === 1 ? first : MIXED_SELECTION
@@ -574,16 +577,21 @@ const appendComboboxRow = (homey: Homey, config: ComboboxConfig): void => {
 }
 
 // One row drives every device of the building; devices without a
-// building (no grouping available) get one row each.
+// building (no grouping available) get one row each. The parameter
+// re-encodes the caller's narrowing — a nullable `name` here would
+// drag a fallback no call can ever reach.
 const appendGroupRow = (
   homey: Homey,
-  group: AdjustableGroup,
+  group: {
+    readonly devices: readonly AdjustableDevice[]
+    readonly name: string
+  },
   index: number,
 ): void => {
   const deviceIds = group.devices.map(({ id }) => id)
   appendComboboxRow(homey, {
     id: `group-${String(index)}`,
-    label: group.name ?? '',
+    label: group.name,
     getValue: (): string => commonSelectionOf(deviceIds),
     setValue: (value): void => {
       for (const deviceId of deviceIds) {
@@ -597,7 +605,8 @@ const appendDeviceRow = (homey: Homey, device: AdjustableDevice): void => {
   appendComboboxRow(homey, {
     id: device.id,
     label: device.name,
-    getValue: (): string => sourceSelections.get(device.id) ?? '',
+    // The one-device group: same accessor, same miss semantics
+    getValue: (): string => commonSelectionOf([device.id]),
     setValue: (value): void => {
       sourceSelections.set(device.id, value)
     },
@@ -615,7 +624,7 @@ const appendSourceRows = (
       }
       continue
     }
-    appendGroupRow(homey, group, index)
+    appendGroupRow(homey, { devices: group.devices, name: group.name }, index)
   }
 }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,5 @@ sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.exclusions=**/*.jpg,**/*.png,coverage/**
-sonar.coverage.exclusions=tests/**,**/*.config.*,scripts/**
+sonar.coverage.exclusions=tests/**,**/*.config.*
 sonar.cpd.exclusions=**/*.config.*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,5 @@ sonar.organization=olivierzal
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.exclusions=**/*.jpg,**/*.png,coverage/**
-sonar.coverage.exclusions=tests/**,**/*.config.*,settings/**,scripts/**
+sonar.coverage.exclusions=tests/**,**/*.config.*,scripts/**
 sonar.cpd.exclusions=**/*.config.*

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -25,3 +25,11 @@ export function cast(value: unknown): never
 export function cast(value: unknown): unknown {
   return value
 }
+
+// Drain the microtask chains a detached (fire-and-forget) run leaves
+// behind: one macrotask turn settles them all when the mocks resolve
+// synchronously. Same helper as com.heatzy's.
+export const settleDetached = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setImmediate(resolve)
+  })

--- a/tests/unit/bundle.test.ts
+++ b/tests/unit/bundle.test.ts
@@ -1,0 +1,177 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The bundler is a top-level-await script working against the current
+// directory (the Homey CLI runs it from the packaged app's root), so
+// each test materializes a miniature app in a temp directory, moves
+// there, and imports the script afresh.
+const HASH_LENGTH = 8
+
+const initialDirectory = process.cwd()
+
+const ENTRY_SOURCE = `export const start = (value?: string): string =>
+  value ?? 'booted'
+`
+
+const PAGE_HTML = `<!doctype html>
+<html lang="en">
+    <head>
+        <!-- index.js is mentioned here and must stay unstamped -->
+        <link href="styles.css" rel="stylesheet">
+        <script defer src="index.js"></script>
+        <script defer src="index.mjs?v=deadbeef"></script>
+        <script data-origin="settings" defer src="/homey.js"></script>
+    </head>
+    <body></body>
+</html>
+`
+
+const hashOf = (content: string | Buffer): string =>
+  createHash('sha256').update(content).digest('hex').slice(0, HASH_LENGTH)
+
+// Cwd-relative on purpose: every test runs from inside its own temp
+// app, exactly where the Homey CLI runs the script from.
+const seedApp = async (): Promise<void> => {
+  await mkdir('settings', { recursive: true })
+  await writeFile('settings/index.mts', ENTRY_SOURCE)
+}
+
+const seedPackagedPage = async (html: string): Promise<void> => {
+  await mkdir('.homeybuild/settings', { recursive: true })
+  await writeFile('.homeybuild/settings/index.html', html)
+  await writeFile('.homeybuild/settings/styles.css', 'body { color: red; }\n')
+}
+
+const runBundler = async (): Promise<void> => {
+  vi.resetModules()
+  await import('../../scripts/bundle.mts')
+}
+
+const packagedFile = async (relativePath: string): Promise<string> =>
+  readFile(path.join('.homeybuild', relativePath), 'utf8')
+
+describe('bundle script', () => {
+  let workDirectory = ''
+
+  beforeEach(async () => {
+    workDirectory = await mkdtemp(path.join(tmpdir(), 'bundle-'))
+    process.chdir(workDirectory)
+    await seedApp()
+  })
+
+  afterEach(async () => {
+    process.chdir(initialDirectory)
+    await rm(workDirectory, { force: true, recursive: true })
+  })
+
+  it('should emit the compat pair into the packaged app', async () => {
+    await runBundler()
+
+    const iife = await packagedFile('settings/index.js')
+    const esm = await packagedFile('settings/index.mjs')
+
+    expect(iife).toContain('var MELCloudWebview')
+    expect(iife).not.toContain('export')
+    expect(esm).toContain('export')
+    // es2020 target: nullish coalescing ships as-is, unlowered
+    expect(iife).toContain('??')
+  })
+
+  it('should stamp references only, and emit the manifest', async () => {
+    await seedPackagedPage(PAGE_HTML)
+
+    await runBundler()
+
+    const stamped = await packagedFile('settings/index.html')
+    const jsHash = hashOf(await packagedFile('settings/index.js'))
+    const cssHash = hashOf(await packagedFile('settings/styles.css'))
+    const mjsHash = hashOf(await packagedFile('settings/index.mjs'))
+
+    expect(stamped).toContain(`href="styles.css?v=${cssHash}"`)
+    expect(stamped).toContain(`src="index.js?v=${jsHash}"`)
+    // The stale stamp is replaced, never doubled
+    expect(stamped).toContain(`src="index.mjs?v=${mjsHash}"`)
+    expect(stamped).not.toContain('deadbeef')
+    // Outside a reference context nothing moves
+    expect(stamped).toContain(
+      '<!-- index.js is mentioned here and must stay unstamped -->',
+    )
+    expect(stamped).toContain('src="/homey.js"')
+
+    const manifest: unknown = JSON.parse(
+      await packagedFile('webview-hashes.json'),
+    )
+
+    // Document order: stylesheet first, then the two bundles
+    expect(manifest).toStrictEqual({
+      settings: [cssHash, jsHash, mjsHash].join('.'),
+    })
+  })
+
+  it('should rewrite nothing when the stamps are already fresh', async () => {
+    await seedPackagedPage(PAGE_HTML)
+
+    await runBundler()
+
+    const once = await packagedFile('settings/index.html')
+
+    await runBundler()
+
+    await expect(packagedFile('settings/index.html')).resolves.toBe(once)
+  })
+
+  it('should move the stamps when an asset changes', async () => {
+    await seedPackagedPage(PAGE_HTML)
+
+    await runBundler()
+
+    const before = await packagedFile('settings/index.html')
+    await writeFile(
+      '.homeybuild/settings/styles.css',
+      'body { color: blue; }\n',
+    )
+
+    await runBundler()
+
+    await expect(packagedFile('settings/index.html')).resolves.not.toBe(before)
+  })
+
+  it('should join identical stamps once, as the page itself does', async () => {
+    await seedPackagedPage(
+      '<html><head><link href="a.css" rel="stylesheet"><link href="b.css" rel="stylesheet"></head></html>',
+    )
+    const twinBytes = 'body { margin: 0; }\n'
+    await writeFile('.homeybuild/settings/a.css', twinBytes)
+    await writeFile('.homeybuild/settings/b.css', twinBytes)
+
+    await runBundler()
+
+    const manifest: unknown = JSON.parse(
+      await packagedFile('webview-hashes.json'),
+    )
+
+    // The page joins UNIQUE stamp values — the manifest must agree, or
+    // twin-byte assets would loop the freshness handshake
+    expect(manifest).toStrictEqual({ settings: hashOf(twinBytes) })
+  })
+
+  it('should stamp nothing in a standalone suite run', async () => {
+    await runBundler()
+
+    await expect(packagedFile('webview-hashes.json')).rejects.toThrow('ENOENT')
+  })
+
+  it('should skip the manifest when a page carries no local reference', async () => {
+    await seedPackagedPage(
+      '<html><head><script src="/homey.js"></script></head></html>',
+    )
+
+    await runBundler()
+
+    await expect(packagedFile('webview-hashes.json')).rejects.toThrow('ENOENT')
+  })
+})

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -1,0 +1,791 @@
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableCSSFileLoading": true, "disableJavaScriptFileLoading": true, "navigation": {"disableMainFrameNavigation": true}}}
+
+import { readFileSync } from 'node:fs'
+
+import type HomeySettings from 'homey/lib/HomeySettings'
+import {
+  getButton,
+  getDetails,
+  getDiv,
+  getFieldset,
+  getSelect,
+} from '@olivierzal/homey-kit/dom'
+import { Temporal } from 'temporal-polyfill'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  AdjustableGroup,
+  TemperatureSensor,
+  TimestampedLog,
+} from '../../types.mts'
+import { mock, settleDetached } from '../helpers.ts'
+
+// A plain relative path: under the happy-dom environment
+// `import.meta.url` is an http URL the fs module refuses.
+const pageHtml = readFileSync('settings/index.html', 'utf8')
+
+// Fixed mid-day clock (only `Date` is faked — `setImmediate` stays real
+// for settleDetached): every relative-time offset below stays inside
+// the intended day in UTC and Europe/Paris alike.
+const NOW_MS = Temporal.Instant.from('2026-08-10T12:00:00Z').epochMilliseconds
+const MINUTES_30_MS = 1_800_000
+const HOURS_2_MS = 7_200_000
+const HOURS_26_MS = 93_600_000
+const DAYS_8_MS = 691_200_000
+
+type ApiCallback = (error: Error | null, result: unknown) => void
+
+interface Harness {
+  readonly alert: ReturnType<typeof vi.fn>
+  readonly api: ReturnType<typeof vi.fn>
+  readonly homey: HomeySettings
+  readonly openURL: ReturnType<typeof vi.fn>
+  readonly ready: ReturnType<typeof vi.fn>
+  readonly routes: Record<string, unknown>
+  readonly emit: (event: string, ...eventArgs: unknown[]) => void
+}
+
+interface HomeyOptions {
+  readonly failures?: Readonly<Record<string, Error>>
+  readonly routes?: Record<string, unknown>
+  readonly shouldRejectAlerts?: boolean
+  readonly storedError?: Error | null
+  readonly storedSettings?: Record<string, unknown> | null
+  readonly translations?: Readonly<Record<string, string>>
+}
+
+const groupsFixture = (): AdjustableGroup[] => [
+  {
+    devices: [
+      { id: 'd1', name: 'Salon', outdoorSource: 'w1:measure_temperature' },
+      { id: 'd2', name: 'Cuisine', outdoorSource: 'w1:measure_temperature' },
+    ],
+    name: 'Maison',
+  },
+  { devices: [{ id: 'd3', name: 'Bureau', outdoorSource: null }], name: null },
+]
+
+// Same building, two different feeds — plus a device-less group whose
+// common value can only be the mixed sentinel.
+const divergedGroupsFixture = (): AdjustableGroup[] => [
+  {
+    devices: [
+      { id: 'd1', name: 'Salon', outdoorSource: 'w1:measure_temperature' },
+      { id: 'd2', name: 'Cuisine', outdoorSource: 'w2:measure_temperature' },
+    ],
+    name: 'Maison',
+  },
+  { devices: [], name: 'Annexe' },
+]
+
+const sensorsFixture = (): TemperatureSensor[] => [
+  { capabilityName: 'Station météo', capabilityPath: 'w1:measure_temperature' },
+  {
+    capabilityName: 'Capteur jardin',
+    capabilityPath: 'w2:measure_temperature',
+  },
+]
+
+const defaultTranslations: Readonly<Record<string, string>> = {
+  'settings.defaultSource': 'Homey weather',
+  'settings.disabledSource': 'Do not adjust',
+  'settings.searchSource': 'Search…',
+}
+
+// The SDK api overloads GET/DELETE (3 args) with POST/PUT (4): the mock
+// mirrors that shape through a rest tuple and picks the trailing
+// callback, whichever slot it landed in.
+type ApiCallArgs = readonly [string, string, ...unknown[]]
+
+const createApiMock = (
+  failures: Readonly<Record<string, Error>>,
+  routes: Record<string, unknown>,
+): ReturnType<typeof vi.fn> =>
+  vi.fn<(...callArgs: ApiCallArgs) => void>((...callArgs) => {
+    const [method, path] = callArgs
+    const callback = callArgs.findLast(
+      (argument): argument is ApiCallback => typeof argument === 'function',
+    )
+    const key = `${method} ${path}`
+    const failure = failures[key]
+    if (failure === undefined) {
+      callback?.(null, routes[key])
+      return
+    }
+    callback?.(failure, null)
+  })
+
+const createAlertMock = (
+  shouldRejectAlerts: boolean,
+): ReturnType<typeof vi.fn<() => Promise<void>>> =>
+  shouldRejectAlerts
+    ? vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValue(new Error('alert channel down'))
+    : vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+const createHarness = (options: HomeyOptions = {}): Harness => {
+  const {
+    failures = {},
+    routes = {},
+    shouldRejectAlerts = false,
+    storedError = null,
+    storedSettings = {},
+    translations = {},
+  } = options
+  const listeners = new Map<string, ((...eventArgs: unknown[]) => void)[]>()
+  const api = createApiMock(failures, routes)
+  const alert = createAlertMock(shouldRejectAlerts)
+  const openURL = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+  const ready = vi.fn<() => void>()
+  const homey = mock<HomeySettings>({
+    alert,
+    api,
+    openURL,
+    ready,
+    __: (key: string): string =>
+      ({ ...defaultTranslations, ...translations })[key] ?? key,
+    get: (callback: (error: Error | null, settings: unknown) => void): void => {
+      callback(storedError, storedSettings)
+    },
+    on: (event: string, listener: (...eventArgs: unknown[]) => void): void => {
+      const bucket = listeners.get(event) ?? []
+      bucket.push(listener)
+      listeners.set(event, bucket)
+    },
+  })
+  return {
+    alert,
+    api,
+    homey,
+    openURL,
+    ready,
+    routes,
+    emit: (event: string, ...eventArgs: unknown[]): void => {
+      const bucket = listeners.get(event)
+      if (bucket === undefined) {
+        return
+      }
+      for (const listener of bucket) {
+        listener(...eventArgs)
+      }
+    },
+  }
+}
+
+const defaultRoutes = (): Record<string, unknown> => ({
+  'GET /devices/groups': groupsFixture(),
+  'GET /devices/sensors/temperature': sensorsFixture(),
+  'GET /language': 'fr',
+  'GET /webview-hashes': {},
+  'POST /boot-error': undefined,
+  'PUT /cooling/auto-adjustment': undefined,
+})
+
+const defaultSettings = (): Record<string, unknown> => ({
+  isEnabled: true,
+  lastLogs: [],
+})
+
+// The page captures its elements at module load, so every boot needs a
+// fresh evaluation against the freshly loaded document.
+const bootPage = async (options: HomeyOptions = {}): Promise<Harness> => {
+  const harness = createHarness({
+    routes: defaultRoutes(),
+    storedSettings: defaultSettings(),
+    ...options,
+  })
+  const { start } = await import('../../settings/index.mts')
+  await start(harness.homey)
+  await settleDetached()
+  return harness
+}
+
+const sourceInput = (id: string): HTMLInputElement => {
+  const element = document.querySelector(`#${CSS.escape(`source-${id}`)}`)
+  if (element instanceof HTMLInputElement) {
+    return element
+  }
+  throw new TypeError(`No combobox input for \`${id}\``)
+}
+
+const optionItems = (input: HTMLInputElement): HTMLLIElement[] => [
+  ...(input.parentElement?.querySelectorAll('li') ?? []),
+]
+
+const pickOption = (input: HTMLInputElement, name: string): void => {
+  const item = optionItems(input).find(
+    ({ textContent }) => textContent === name,
+  )
+  if (item === undefined) {
+    throw new TypeError(`No option named \`${name}\``)
+  }
+  item.click()
+}
+
+const commitEnabled = (value: string): void => {
+  const element = getSelect('enabled')
+  element.value = value
+  element.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+const logRows = (): HTMLDivElement[] => [
+  ...getDiv('logs').querySelectorAll<HTMLDivElement>('.log-row'),
+]
+
+const logDays = (): HTMLDivElement[] => [
+  ...getDiv('logs').querySelectorAll<HTMLDivElement>('.log-day'),
+]
+
+// DOMParser never executes scripts, which is exactly why it is the
+// sanctioned way to load the real page into the simulated DOM; appended
+// nodes are auto-adopted across documents.
+const loadPage = (): void => {
+  const parser = new DOMParser()
+  const parsed = parser.parseFromString(pageHtml, 'text/html')
+  // Stylesheets are inert under happy-dom, but adopting the <link>
+  // still fires its loader against the test origin — drop it.
+  for (const link of parsed.head.querySelectorAll('link')) {
+    link.remove()
+  }
+  document.head.replaceChildren(...parsed.head.children)
+  document.body.replaceChildren(...parsed.body.children)
+}
+
+describe('settings page', () => {
+  let reportErrorMock = vi.fn<(error: unknown) => void>()
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers({ now: NOW_MS, toFake: ['Date'] })
+    reportErrorMock = vi.fn<(error: unknown) => void>()
+    vi.stubGlobal('reportError', reportErrorMock)
+    sessionStorage.clear()
+    loadPage()
+    document.documentElement.lang = 'en'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  describe('boot', () => {
+    it('should build the source rows and seed their selections', async () => {
+      const { ready } = await bootPage()
+
+      expect(ready).toHaveBeenCalledTimes(1)
+      expect(document.documentElement.lang).toBe('fr')
+      expect(sourceInput('group-0').value).toBe('Station météo')
+      expect(sourceInput('group-0').placeholder).toBe('Search…')
+      expect(sourceInput('group-0').ariaLabel).toBe('Maison — Search…')
+      expect(sourceInput('d3').value).toBe('Homey weather')
+      expect(getSelect('enabled').value).toBe('true')
+      expect(getDetails('configuration').open).toBe(false)
+      expect(getButton('apply').disabled).toBe(true)
+      expect(getDiv('empty_state').hidden).toBe(true)
+    })
+
+    it('should open the configuration when adjustment is disabled', async () => {
+      await bootPage({ storedSettings: { isEnabled: false } })
+
+      expect(getSelect('enabled').value).toBe('false')
+      expect(getDetails('configuration').open).toBe(true)
+    })
+
+    it('should not yank the panel shut when Refresh re-reads', async () => {
+      await bootPage({ storedSettings: { isEnabled: false } })
+
+      getDetails('configuration').open = false
+      getButton('refresh').click()
+      await settleDetached()
+
+      expect(getDetails('configuration').open).toBe(false)
+    })
+
+    it('should show a diverged or empty group as a blank field', async () => {
+      await bootPage({
+        routes: {
+          ...defaultRoutes(),
+          'GET /devices/groups': divergedGroupsFixture(),
+        },
+      })
+
+      expect(sourceInput('group-0').value).toBe('')
+      expect(sourceInput('group-1').value).toBe('')
+    })
+
+    it('should keep the authored language when the read fails', async () => {
+      await bootPage({ failures: { 'GET /language': new Error('offline') } })
+
+      expect(document.documentElement.lang).toBe('en')
+      expect(sourceInput('d3').value).toBe('Homey weather')
+    })
+
+    it('should point an empty install to the store page', async () => {
+      const { openURL } = await bootPage({
+        routes: { ...defaultRoutes(), 'GET /devices/groups': [] },
+      })
+
+      expect(getDiv('empty_state').hidden).toBe(false)
+
+      getButton('install').click()
+
+      expect(openURL).toHaveBeenCalledWith('https://homey.app/a/com.mecloud')
+    })
+
+    it.each([
+      ['serialized NotFoundError', new Error('notFound')],
+      ['bridge wording', new Error('Not found: GET /api/app/com.mecloud')],
+    ])('should read a %s as no devices, silently', async (_name, error) => {
+      const { alert } = await bootPage({
+        failures: {
+          'GET /devices/groups': error,
+          'GET /devices/sensors/temperature': error,
+        },
+      })
+
+      expect(alert).not.toHaveBeenCalled()
+      expect(getDiv('empty_state').hidden).toBe(false)
+    })
+
+    it('should alert any other list failure and degrade to empty', async () => {
+      const { alert } = await bootPage({
+        failures: { 'GET /devices/groups': new Error('boom') },
+      })
+
+      expect(alert).toHaveBeenCalledWith('boom')
+      expect(getDiv('empty_state').hidden).toBe(false)
+    })
+
+    it('should alert when the settings store read fails', async () => {
+      const { alert } = await bootPage({
+        storedError: new Error('storage down'),
+      })
+
+      expect(alert).toHaveBeenCalledWith('storage down')
+    })
+
+    it('should release the controls and surface a failed init', async () => {
+      const { alert, ready } = await bootPage({
+        shouldRejectAlerts: true,
+        storedError: new Error('storage down'),
+      })
+
+      expect(ready).toHaveBeenCalledTimes(1)
+      expect(alert).toHaveBeenCalledWith('storage down')
+      expect(getButton('refresh').disabled).toBe(false)
+      expect(reportErrorMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('log pane', () => {
+    it('should rebuild the retained logs newest first with day separators', async () => {
+      await bootPage({
+        storedSettings: {
+          isEnabled: true,
+          // Newest first, the order the app persists them in
+          lastLogs: [
+            {
+              category: 'calculated',
+              message: 'Target reached',
+              time: NOW_MS - MINUTES_30_MS,
+            },
+            {
+              category: 'saved',
+              message: 'Old push',
+              time: NOW_MS - HOURS_26_MS,
+            },
+            { message: 'Too old', time: NOW_MS - DAYS_8_MS },
+          ] satisfies TimestampedLog[],
+        },
+      })
+
+      const rows = logRows()
+
+      expect(rows).toHaveLength(2)
+      expect(logDays()).toHaveLength(2)
+      expect(rows[0]?.textContent).toContain('Target reached')
+      expect(rows[0]?.textContent).toContain('il y a 30 minutes')
+      expect(rows[0]?.textContent).toContain('🎯')
+      expect(rows[0]?.querySelector('.log-message-calculated')).not.toBeNull()
+      expect(
+        rows[0]?.querySelector<HTMLDivElement>('.log-time')?.title,
+      ).not.toBe('')
+      expect(rows[1]?.textContent).toContain('Old push')
+      expect(rows[1]?.textContent).toContain('☁️')
+      expect(rows[1]?.textContent).not.toContain('il y a')
+    })
+
+    it('should keep the pane empty without retained logs', async () => {
+      await bootPage({ storedSettings: { isEnabled: true, lastLogs: null } })
+
+      expect(logRows()).toHaveLength(0)
+    })
+
+    it.each([
+      ['an unknown category', 'mystery'],
+      ['no category', undefined],
+    ])('should style %s as an error', async (_name, category) => {
+      const { emit } = await bootPage()
+
+      emit('log', {
+        category,
+        message: 'Went wrong',
+        time: NOW_MS - HOURS_2_MS,
+      })
+
+      const [row] = logRows()
+
+      expect(row?.textContent).toContain('⚠️')
+      expect(row?.textContent).toContain('il y a 2 heures')
+      expect(row?.querySelector('.log-message-error')).not.toBeNull()
+    })
+
+    it('should insert a same-day live log right below the separator', async () => {
+      const { emit } = await bootPage({
+        storedSettings: {
+          isEnabled: true,
+          lastLogs: [
+            {
+              category: 'listened',
+              message: 'First',
+              time: NOW_MS - HOURS_2_MS,
+            },
+          ] satisfies TimestampedLog[],
+        },
+      })
+
+      emit('log', {
+        category: 'created',
+        message: 'Second',
+        time: NOW_MS - MINUTES_30_MS,
+      })
+
+      expect(logRows().map(({ textContent }) => textContent)).toStrictEqual([
+        expect.stringContaining('Second'),
+        expect.stringContaining('First'),
+      ])
+      expect(logDays()).toHaveLength(1)
+    })
+
+    it('should open a new day block for an out-of-day live log', async () => {
+      const { emit } = await bootPage()
+
+      emit('log', { category: 'saved', message: 'Now', time: NOW_MS })
+      emit('log', {
+        category: 'reverted',
+        message: 'Belated',
+        time: NOW_MS - HOURS_26_MS,
+      })
+
+      expect(logDays()).toHaveLength(2)
+      expect(logRows()[0]?.textContent).toContain('Belated')
+    })
+
+    it('should keep the live rows across a Refresh', async () => {
+      const { emit } = await bootPage()
+
+      emit('log', { category: 'cleaned', message: 'Kept', time: NOW_MS })
+      getButton('refresh').click()
+      await settleDetached()
+
+      expect(logRows()).toHaveLength(1)
+      expect(logRows()[0]?.textContent).toContain('Kept')
+    })
+  })
+
+  describe('source combobox', () => {
+    it('should drop the full list on click with the selection marked', async () => {
+      await bootPage()
+
+      const input = sourceInput('group-0')
+      input.click()
+      const items = optionItems(input)
+
+      expect(input.getAttribute('aria-expanded')).toBe('true')
+      expect(items.map(({ textContent }) => textContent)).toStrictEqual([
+        'Do not adjust',
+        'Homey weather',
+        'Station météo',
+        'Capteur jardin',
+      ])
+      expect(
+        items
+          .find(({ textContent }) => textContent === 'Station météo')
+          ?.getAttribute('aria-selected'),
+      ).toBe('true')
+      expect(
+        items
+          .find(({ textContent }) => textContent === 'Homey weather')
+          ?.getAttribute('aria-selected'),
+      ).toBe('false')
+    })
+
+    it('should switch to typing mode on the second tap only', async () => {
+      await bootPage()
+
+      const input = sourceInput('group-0')
+      input.click()
+
+      expect(input.inputMode).toBe('none')
+
+      input.click()
+
+      expect(input.inputMode).toBe('text')
+
+      input.click()
+
+      expect(input.inputMode).toBe('text')
+      expect(input.getAttribute('aria-expanded')).toBe('true')
+    })
+
+    it('should filter the options while typing', async () => {
+      await bootPage()
+
+      const input = sourceInput('group-0')
+      input.click()
+      input.value = 'jardin'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(
+        optionItems(input).map(({ textContent }) => textContent),
+      ).toStrictEqual(['Capteur jardin'])
+    })
+
+    it('should reopen a closed list when typing resumes', async () => {
+      await bootPage()
+
+      const input = sourceInput('group-0')
+      input.click()
+      document.body.dispatchEvent(
+        new MouseEvent('pointerdown', { bubbles: true }),
+      )
+
+      expect(input.getAttribute('aria-expanded')).toBe('false')
+
+      input.value = 'station'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+
+      expect(input.getAttribute('aria-expanded')).toBe('true')
+      expect(
+        optionItems(input).map(({ textContent }) => textContent),
+      ).toStrictEqual(['Station météo'])
+    })
+
+    it('should write a group pick to every device and arm Apply', async () => {
+      const { api } = await bootPage()
+
+      const input = sourceInput('group-0')
+      input.click()
+      pickOption(input, 'Capteur jardin')
+
+      expect(input.value).toBe('Capteur jardin')
+      expect(input.getAttribute('aria-expanded')).toBe('false')
+      expect(getButton('apply').disabled).toBe(false)
+
+      getButton('apply').click()
+      await settleDetached()
+
+      expect(api).toHaveBeenCalledWith(
+        'PUT',
+        '/cooling/auto-adjustment',
+        {
+          isEnabled: true,
+          outdoorSources: {
+            d1: 'w2:measure_temperature',
+            d2: 'w2:measure_temperature',
+            d3: null,
+          },
+        },
+        expect.any(Function),
+      )
+      expect(getButton('apply').disabled).toBe(true)
+    })
+
+    it('should auto-enable the adjustment when a source is picked', async () => {
+      await bootPage({ storedSettings: { isEnabled: false } })
+
+      const input = sourceInput('d3')
+      input.click()
+      pickOption(input, 'Do not adjust')
+
+      expect(getSelect('enabled').value).toBe('true')
+      expect(getButton('apply').disabled).toBe(false)
+    })
+
+    it('should ignore the click a scroll gesture lands on', async () => {
+      await bootPage()
+
+      const input = sourceInput('group-0')
+      input.click()
+      const list = input.parentElement?.querySelector('ul')
+      list?.dispatchEvent(
+        new MouseEvent('pointerdown', { clientX: 0, clientY: 0 }),
+      )
+      const item = optionItems(input).find(
+        ({ textContent }) => textContent === 'Capteur jardin',
+      )
+      item?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, clientX: 0, clientY: 40 }),
+      )
+
+      expect(input.getAttribute('aria-expanded')).toBe('true')
+
+      item?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, clientX: 0, clientY: 4 }),
+      )
+
+      expect(input.getAttribute('aria-expanded')).toBe('false')
+      expect(input.value).toBe('Capteur jardin')
+    })
+
+    it('should let only one list stay open', async () => {
+      await bootPage()
+
+      const groupInput = sourceInput('group-0')
+      const deviceInput = sourceInput('d3')
+      groupInput.click()
+      deviceInput.click()
+
+      expect(groupInput.getAttribute('aria-expanded')).toBe('false')
+      expect(deviceInput.getAttribute('aria-expanded')).toBe('true')
+    })
+
+    it('should close on an outside press and stay open on an inside one', async () => {
+      await bootPage()
+
+      const input = sourceInput('group-0')
+      input.click()
+      input.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }))
+
+      expect(input.getAttribute('aria-expanded')).toBe('true')
+
+      document.dispatchEvent(new Event('pointerdown'))
+
+      expect(input.getAttribute('aria-expanded')).toBe('false')
+    })
+
+    it('should show a diverged group as blank and restore it on close', async () => {
+      await bootPage({
+        routes: {
+          ...defaultRoutes(),
+          'GET /devices/groups': divergedGroupsFixture(),
+        },
+      })
+
+      const input = sourceInput('group-0')
+      input.click()
+
+      expect(
+        optionItems(input).every(
+          (item) => item.getAttribute('aria-selected') === 'false',
+        ),
+      ).toBe(true)
+
+      document.body.dispatchEvent(
+        new MouseEvent('pointerdown', { bubbles: true }),
+      )
+
+      expect(input.value).toBe('')
+    })
+  })
+
+  describe('adjustment form', () => {
+    it('should arm Apply on an enable flip and disarm on revert', async () => {
+      await bootPage()
+
+      commitEnabled('false')
+
+      expect(getButton('apply').disabled).toBe(false)
+
+      commitEnabled('true')
+
+      expect(getButton('apply').disabled).toBe(true)
+    })
+
+    it('should push the disabled state without re-enabling it', async () => {
+      const { api } = await bootPage()
+
+      commitEnabled('false')
+      getButton('apply').click()
+      await settleDetached()
+
+      expect(api).toHaveBeenCalledWith(
+        'PUT',
+        '/cooling/auto-adjustment',
+        expect.objectContaining({ isEnabled: false }),
+        expect.any(Function),
+      )
+      expect(getSelect('enabled').value).toBe('false')
+      expect(getButton('apply').disabled).toBe(true)
+    })
+
+    it('should alert a failed push and keep the form armed', async () => {
+      const { alert } = await bootPage({
+        failures: { 'PUT /cooling/auto-adjustment': new Error('offline') },
+      })
+
+      commitEnabled('false')
+      getButton('apply').click()
+      await settleDetached()
+
+      expect(alert).toHaveBeenCalledWith('offline')
+      expect(getButton('apply').disabled).toBe(false)
+      expect(getButton('refresh').disabled).toBe(false)
+      expect(getFieldset('adjustment').disabled).toBe(false)
+    })
+
+    it('should restore the saved values on Refresh', async () => {
+      await bootPage()
+
+      commitEnabled('false')
+      const input = sourceInput('group-0')
+      input.click()
+      pickOption(input, 'Do not adjust')
+      getButton('refresh').click()
+      await settleDetached()
+
+      expect(getSelect('enabled').value).toBe('true')
+      expect(sourceInput('group-0').value).toBe('Station météo')
+      expect(getButton('apply').disabled).toBe(true)
+    })
+  })
+
+  describe('freshness', () => {
+    it('should refetch a stale page and skip the build entirely', async () => {
+      const stamped = document.createElement('link')
+      stamped.setAttribute('href', 'styles.css?v=aaaa1111')
+      document.head.append(stamped)
+      const { api, ready } = await bootPage({
+        routes: {
+          ...defaultRoutes(),
+          'GET /webview-hashes': { settings: 'bbbb2222' },
+        },
+      })
+
+      expect(api).toHaveBeenCalledWith(
+        'POST',
+        '/boot-error',
+        expect.objectContaining({ name: 'WebviewFreshness' }),
+        expect.any(Function),
+      )
+      expect(api).not.toHaveBeenCalledWith(
+        'GET',
+        '/devices/groups',
+        expect.any(Function),
+      )
+      expect(ready).not.toHaveBeenCalled()
+    })
+
+    it('should re-run the handshake on the app boot poke', async () => {
+      const { emit } = await bootPage()
+
+      emit('webview_hashes_changed')
+      await settleDetached()
+
+      expect(logRows()).toHaveLength(0)
+    })
+  })
+})

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -25,9 +25,9 @@ import { mock, settleDetached } from '../helpers.ts'
 // `import.meta.url` is an http URL the fs module refuses.
 const pageHtml = readFileSync('settings/index.html', 'utf8')
 
-// Fixed mid-day clock (only `Date` is faked — `setImmediate` stays real
-// for settleDetached): every relative-time offset below stays inside
-// the intended day in UTC and Europe/Paris alike.
+// Fixed mid-day clock (pinned at `Temporal.Now`, so `setImmediate`
+// stays real for settleDetached): every relative-time offset below
+// stays inside the intended day in UTC and Europe/Paris alike.
 const NOW_MS = Temporal.Instant.from('2026-08-10T12:00:00Z').epochMilliseconds
 const MINUTES_30_MS = 1_800_000
 const HOURS_2_MS = 7_200_000
@@ -258,7 +258,19 @@ describe('settings page', () => {
 
   beforeEach(() => {
     vi.resetModules()
-    vi.useFakeTimers({ now: NOW_MS, toFake: ['Date'] })
+    // The page reads its clock through `Temporal.Now`, and
+    // temporal-polyfill defers to the runtime's native Temporal when one
+    // exists — a faked `Date` never reaches that native clock, so the
+    // pin lands on `Temporal.Now` itself. `timeZoneId` stays live: the
+    // fixture offsets are chosen to survive any zone.
+    vi.spyOn(Temporal.Now, 'instant').mockReturnValue(
+      Temporal.Instant.fromEpochMilliseconds(NOW_MS),
+    )
+    vi.spyOn(Temporal.Now, 'zonedDateTimeISO').mockImplementation(() =>
+      Temporal.Instant.fromEpochMilliseconds(NOW_MS).toZonedDateTimeISO(
+        Temporal.Now.timeZoneId(),
+      ),
+    )
     reportErrorMock = vi.fn<(error: unknown) => void>()
     vi.stubGlobal('reportError', reportErrorMock)
     sessionStorage.clear()
@@ -267,7 +279,9 @@ describe('settings page', () => {
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    // The spies sit on a module-level object shared across the worker's
+    // test files — restore them so later files see the real clock.
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { type ViteUserConfig, defineConfig } from 'vitest/config'
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
-      exclude: ['.homeybuild/**', 'scripts/**/*.mts', 'settings/**/*.mts'],
+      exclude: ['.homeybuild/**', 'scripts/**/*.mts'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { type ViteUserConfig, defineConfig } from 'vitest/config'
 const config: ViteUserConfig = defineConfig({
   test: {
     coverage: {
-      exclude: ['.homeybuild/**', 'scripts/**/*.mts'],
+      exclude: ['.homeybuild/**'],
       include: ['**/*.mts'],
       reporter: ['text', 'lcov'],
       thresholds: {


### PR DESCRIPTION
Second slice of the real-coverage campaign (model: the com.heatzy pilot #1099), now covering the two silent caps this repo carried: `settings/**` and `scripts/**` were excluded from coverage (vitest and `sonar.coverage.exclusions` alike) while `settings/index.mts` (762 lines, the whole page) and `scripts/bundle.mts` (the `?v=`-stamping bundler, the #1404 root-cause class) are shipped code.

## Before / after

| | before | after |
|---|---|---|
| Statements | 56.83 % (399/702) | **100 % (744/744)** |
| Branches | — | **100 % (238/238)** |
| Functions | — | **100 % (214/214)** |
| Lines | — | **100 % (737/737)** |

No scoped exception anywhere: thresholds stay at a bare global 100.

## Settings page (34 tests)

happy-dom harness loading the REAL `settings/index.html` via DOMParser, real kit primitives (dirty-gate, boot, freshness), only the SDK boundary mocked. Boot/seeding, journal (retention, day separators, live inserts, category icons, French relative times), sources combobox (open/filter/pick/drag-slop/outside-close), group writes with exact PUT payloads, adjustment gate arm/freeze/failure paths, freshness handshake (stale identity → boot-error breadcrumb, ready withheld).

Three dead branches were eliminated by rewrite, not exclusion (pilot doctrine): a branchless `children.item(1)` insert, narrowing re-encoded in `appendGroupRow`'s parameter type, and a unified `commonSelectionOf` accessor whose every arm a test reaches.

## Bundler (7 tests)

Temp-filesystem harness running the real script from a miniature app root: compat pair emitted (`index.js` IIFE with `MELCloudWebview` + `index.mjs` ESM, es2020 preserved), stamping confined to attribute reference contexts (a comment naming `index.js` stays untouched), stale stamps replaced, idempotence, manifest in document order, both standalone flows (no packaged HTML / no local references → no manifest).

Product-side corrections the harness surfaced:

- **esbuild cwd anchoring** — the service process outlives the module and keeps its own working directory; entries are now pinned with an explicit `absWorkingDir`.
- **Manifest dedup parity** — the page's own join (`webview-freshness`) dedupes stamps through a `Set` of VALUES; the bundler deduped by FILE, so two assets with identical bytes would emit a diverging identity and loop the freshness handshake into a boot-error. The manifest now joins unique stamp values, pinned by test. The com.melcloud twin carries the same shape and should follow separately.
- **Node-latest CI fix** — `temporal-polyfill` defers to the runtime's native `Temporal` when one exists (Node latest ships it), so faking `Date` never reached the page's clock; the harness now pins `Temporal.Now` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3