### PR TITLE
chore: say why the generated manifests skip Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
 *.html
+# Written by the Homey CLI on every preprocess, without a trailing
+# newline, and committed in that exact form: Prettier would add the
+# newline back and put the tree out of step with the next CLI run.
 /.homeycompose/app.json
 /app.json
 /locales/


### PR DESCRIPTION
`.prettierignore` listed the three CLI-written paths with no reason. Measured: `app.json`, `locales/*.json` and `.homeycompose/app.json` all end on `}` with no trailing newline, and Prettier rewrites all three — so the entries are load-bearing, not leftovers.

The `*.html` line is deliberately left alone: it is being removed in a separate change that hands HTML formatting back to Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3