### PR TITLE
build: adopt configs 1.8.0 and hand the HTML to Prettier

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
     with:
-      # The fleet's Node major — measured 22.20/22.23 on-device
-      # (2026-08); the coverage/Sonar leg tracks it, not lts/*.
-      coverage-node-version: '22'
+      # The fleet's floor, measured on-device (2026-08): 22.20 on a Pro
+      # 2019, 22.23 on a Pro 2023. `22` resolves to the head of the line
+      # and drifts off that floor, so the coverage/Sonar leg names the
+      # minor itself. The quotes are load-bearing: unquoted, `22.20` is
+      # JSON for the number 22.2.
+      coverage-node-version: '22.20'
+      node-versions: '["22", "22.20", "latest", "lts/*"]'
 name: CI
 on:
   merge_group: {}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
     with:
       repo-guidance: 'The app ids `com.mecloud` and `com.mecloud.extension` carry a load-bearing historical typo — never "correct" the spelling anywhere (manifest, code, docs or links). When the bump is `@olivierzal/configs`, move the workflow `uses:` refs to the tag the npm pin names, since one version covers both channels, and resolve every version comment against the upstream with `git ls-remote --tags` instead of guessing it. Stop and leave the PR red when the release changes lint policy: adopting that needs a per-repo verdict, not an automated fix.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`, and `npm run homey:validate`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@91cfb98049d20d3c62d1f21b34a4769672040d95 # v1.8.0
 name: zizmor
 on:
   merge_group: {}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-*.html
 # Written by the Homey CLI on every preprocess, without a trailing
 # newline, and committed in that exact form: Prettier would add the
 # newline back and put the tree out of step with the next CLI run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.6.0",
+        "@olivierzal/configs": "1.8.0",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.6.0/474d9fe4cb9ff56cee39a9e62660cb26f9fd71ed",
-      "integrity": "sha512-l+JqAg4eXdPjQFxRKqK1jZg86ki67MAVqJq6wesx5ZrKULic+NDMG0UNT+zf3dC0He+6Jh/rpvZPdxYWlpO6nw==",
+      "version": "1.8.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.8.0/d708e6a3522b167c2f6151a8cd95113813a87ffb",
+      "integrity": "sha512-GfpGEX1SouX/o4gzDvM4oYmDNObCFKgLCPdM0f/Qa/LqZ7Ra0TQzrthM3NDsey6ru9R9BryVlZ+qgJTwzG6KmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.6.0",
+    "@olivierzal/configs": "1.8.0",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,115 +1,139 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta content="width=device-width, initial-scale=1.0" name="viewport">
-        <title>MELCloud Extension Settings</title>
-        <script>
-            // The page bundle loads as a classic defer script, not an ES
-            // module: a static module script stalls the whole boot on a
-            // cold webview open (a stalled module fetch also blocks
-            // onHomeyReady — proven on-device on com.melcloud), while
-            // classic scripts, like the stylesheet, load cold. defer runs
-            // it after <body> parses (so the entry's top-level DOM
-            // lookups are safe) and before onHomeyReady; the poll keeps
-            // the boot bounded — it hands the instance to the bundle's
-            // start, or reports why and ends the overlay if it failed to
-            // load.
-            function onHomeyReady(homey) {
-                const deadline = Date.now() + 10000
-                const waitForBundle = () => {
-                    if (globalThis.MELCloudWebview) {
-                        globalThis.MELCloudWebview.start(homey)
-                    } else if (Date.now() > deadline) {
-                        // Boot beacon: the bundle never booted — report WHY
-                        // before degrading. A 200 probe with no global means
-                        // the script fetched but failed to parse/run (old
-                        // engine); a probe error means the fetch itself
-                        // fails on this device.
-                        const script = document.querySelector('script[src*="index.js"]')
-                        const report = (probe) => {
-                            homey.api('POST', '/boot-error', { message: 'The settings bundle did not boot within 10s', name: 'BootTimeout', probe, userAgent: navigator.userAgent }, () => {})
-                            homey.ready()
-                            homey.alert(homey.__('settings.loadFailed')).catch(() => {})
-                        }
-                        fetch(script ? script.src : 'index.js')
-                            .then((response) => { report('fetch ' + String(response.status)) })
-                            .catch((error) => { report('fetch failed: ' + String(error)) })
-                    } else {
-                        setTimeout(waitForBundle, 50)
-                    }
-                }
-                waitForBundle()
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>MELCloud Extension Settings</title>
+    <script>
+      // The page bundle loads as a classic defer script, not an ES
+      // module: a static module script stalls the whole boot on a
+      // cold webview open (a stalled module fetch also blocks
+      // onHomeyReady — proven on-device on com.melcloud), while
+      // classic scripts, like the stylesheet, load cold. defer runs
+      // it after <body> parses (so the entry's top-level DOM
+      // lookups are safe) and before onHomeyReady; the poll keeps
+      // the boot bounded — it hands the instance to the bundle's
+      // start, or reports why and ends the overlay if it failed to
+      // load.
+      function onHomeyReady(homey) {
+        const deadline = Date.now() + 10000
+        const waitForBundle = () => {
+          if (globalThis.MELCloudWebview) {
+            globalThis.MELCloudWebview.start(homey)
+          } else if (Date.now() > deadline) {
+            // Boot beacon: the bundle never booted — report WHY
+            // before degrading. A 200 probe with no global means
+            // the script fetched but failed to parse/run (old
+            // engine); a probe error means the fetch itself
+            // fails on this device.
+            const script = document.querySelector('script[src*="index.js"]')
+            const report = (probe) => {
+              homey.api(
+                'POST',
+                '/boot-error',
+                {
+                  message: 'The settings bundle did not boot within 10s',
+                  name: 'BootTimeout',
+                  probe,
+                  userAgent: navigator.userAgent,
+                },
+                () => {},
+              )
+              homey.ready()
+              homey.alert(homey.__('settings.loadFailed')).catch(() => {})
             }
-        </script>
-        <link href="styles.css" rel="stylesheet">
-        <script defer src="index.js"></script>
-        <script data-origin="settings" defer src="/homey.js"></script>
-        <meta content="MELCloud extension settings" name="description">
-    </head>
-    <body>
-        <header class="homey-header">
-            <h1 class="homey-title" data-i18n="settings.title">MELCloud extension settings</h1>
-        </header>
-        <!-- Collapsible: opens folded when adjustment is already enabled
+            fetch(script ? script.src : 'index.js')
+              .then((response) => {
+                report('fetch ' + String(response.status))
+              })
+              .catch((error) => {
+                report('fetch failed: ' + String(error))
+              })
+          } else {
+            setTimeout(waitForBundle, 50)
+          }
+        }
+        waitForBundle()
+      }
+    </script>
+    <link href="styles.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+    <script data-origin="settings" defer src="/homey.js"></script>
+    <meta content="MELCloud extension settings" name="description" />
+  </head>
+  <body>
+    <header class="homey-header">
+      <h1 class="homey-title" data-i18n="settings.title">
+        MELCloud extension settings
+      </h1>
+    </header>
+    <!-- Collapsible: opens folded when adjustment is already enabled
             (the tuning is done), expanded otherwise (setup pending). -->
-        <details id="configuration" class="homey-form-fieldset">
-            <summary
-                id="configuration_summary"
-                class="homey-form-legend"
-                data-i18n="settings.configuration"
-            >Configuration</summary>
-            <fieldset
-                id="sources"
-                class="busy-scope"
-                aria-labelledby="configuration_summary"
-            ></fieldset>
-            <div id="empty_state" hidden>
-                <p data-i18n="settings.notFound">First, you need to set up your devices in the MELCloud Homey app.</p>
-                <button
-                    id="install"
-                    type="button"
-                    class="homey-button-primary-full"
-                    data-i18n="settings.install"
-                >Install the MELCloud app</button>
-            </div>
-        </details>
-        <fieldset id="adjustment" class="homey-form-fieldset">
-            <legend class="homey-form-legend" data-i18n="settings.autoAdjust">Auto-adjust air conditioning temperature</legend>
-            <div class="homey-form-group">
-                <label
-                    class="homey-form-label"
-                    data-i18n="settings.enabled"
-                    for="enabled"
-                >Enabled</label>
-                <select id="enabled" class="homey-form-select">
-                    <option data-i18n="settings.boolean.false" value="false">No</option>
-                    <option data-i18n="settings.boolean.true" value="true">Yes</option>
-                </select>
-            </div>
-            <div class="container">
-                <button
-                    id="refresh"
-                    type="button"
-                    class="homey-button-secondary-shadow"
-                    data-i18n="settings.refresh"
-                >Refresh</button>
-                <button
-                    id="apply"
-                    type="button"
-                    class="homey-button-danger-shadow"
-                    data-i18n="settings.update"
-                >Update</button>
-            </div>
-        </fieldset>
-        <fieldset class="homey-form-fieldset">
-            <legend class="homey-form-legend" data-i18n="settings.log"></legend>
-            <div
-                id="logs"
-                class="homey-form-group"
-                aria-label="Log"
-                role="log"
-            ></div>
-        </fieldset>
-    </body>
+    <details id="configuration" class="homey-form-fieldset">
+      <summary
+        id="configuration_summary"
+        class="homey-form-legend"
+        data-i18n="settings.configuration"
+      >
+        Configuration
+      </summary>
+      <fieldset
+        id="sources"
+        class="busy-scope"
+        aria-labelledby="configuration_summary"
+      ></fieldset>
+      <div id="empty_state" hidden>
+        <p data-i18n="settings.notFound">
+          First, you need to set up your devices in the MELCloud Homey app.
+        </p>
+        <button
+          id="install"
+          type="button"
+          class="homey-button-primary-full"
+          data-i18n="settings.install"
+        >
+          Install the MELCloud app
+        </button>
+      </div>
+    </details>
+    <fieldset id="adjustment" class="homey-form-fieldset">
+      <legend class="homey-form-legend" data-i18n="settings.autoAdjust">
+        Auto-adjust air conditioning temperature
+      </legend>
+      <div class="homey-form-group">
+        <label
+          class="homey-form-label"
+          data-i18n="settings.enabled"
+          for="enabled"
+          >Enabled</label
+        >
+        <select id="enabled" class="homey-form-select">
+          <option data-i18n="settings.boolean.false" value="false">No</option>
+          <option data-i18n="settings.boolean.true" value="true">Yes</option>
+        </select>
+      </div>
+      <div class="container">
+        <button
+          id="refresh"
+          type="button"
+          class="homey-button-secondary-shadow"
+          data-i18n="settings.refresh"
+        >
+          Refresh
+        </button>
+        <button
+          id="apply"
+          type="button"
+          class="homey-button-danger-shadow"
+          data-i18n="settings.update"
+        >
+          Update
+        </button>
+      </div>
+    </fieldset>
+    <fieldset class="homey-form-fieldset">
+      <legend class="homey-form-legend" data-i18n="settings.log"></legend>
+      <div id="logs" class="homey-form-group" aria-label="Log" role="log"></div>
+    </fieldset>
+  </body>
 </html>

--- a/tests/unit/bundle.test.ts
+++ b/tests/unit/bundle.test.ts
@@ -17,16 +17,25 @@ const ENTRY_SOURCE = `export const start = (value?: string): string =>
   value ?? 'booted'
 `
 
+// Prettier owns the page's shape, so the fixture carries the two forms
+// it emits: attributes inline, and — once a tag outgrows the print
+// width — one per line. A reference pattern scoped to a tag or to a
+// single line would still stamp the inline form and silently miss the
+// exploded one.
 const PAGE_HTML = `<!doctype html>
 <html lang="en">
-    <head>
-        <!-- index.js is mentioned here and must stay unstamped -->
-        <link href="styles.css" rel="stylesheet">
-        <script defer src="index.js"></script>
-        <script defer src="index.mjs?v=deadbeef"></script>
-        <script data-origin="settings" defer src="/homey.js"></script>
-    </head>
-    <body></body>
+  <head>
+    <!-- index.js is mentioned here and must stay unstamped -->
+    <link href="styles.css" rel="stylesheet" />
+    <script defer src="index.js"></script>
+    <script
+      data-testid="a-tag-past-the-print-width-that-prettier-explodes"
+      defer
+      src="index.mjs?v=deadbeef"
+    ></script>
+    <script data-origin="settings" defer src="/homey.js"></script>
+  </head>
+  <body></body>
 </html>
 `
 


### PR DESCRIPTION
Adopts `@olivierzal/configs@1.8.0` and completes the HTML formatting shift it unblocks.

## Why the two travel together

The 1.8.0 preset stops enforcing what Prettier decides. Four `html/` rules actively **rejected** Prettier's output (`indent`, `attrs-newline`, `no-extra-spacing-tags`, `require-closing-tags`), so removing `*.html` from `.prettierignore` was only safe once they were gone. `html/sort-attrs`, `head-order` and `no-whitespace-only-children` stay on — Prettier does not do them.

## The coverage guard

1.8.0's reusable CI fails the `check` job when `coverage-node-version` names a version the matrix never carries. Until now a typo selected no leg, so `npm test -- --coverage` and the Sonar upload silently stopped running behind green legs — and neither `Test (Node latest)` nor SonarCloud is a required context anywhere, so nothing downstream caught it.

The matrix now names the fleet's real floor. Measured on-device (2026-08): **22.20** on a Pro 2019, **22.23** on a Pro 2023 — while `22` and `lts/*` both resolve to the head of their line, so no leg exercised 22.20. Keeping `"22"` alongside `"22.20"` leaves `ci / Test (Node 22)` reporting under its current name, so **no ruleset changes**.

Both guards verified from this repo:

```
checked 14 pinned reference(s) across 12 file(s)
coverage runs on the Node 22.20 leg of ["22", "22.20", "latest", "lts/*"]
```

## The `?v=` stamping survives — proven, not assumed

`scripts/bundle.mts` finds local assets by regex in attribute context, and Prettier rewrites attributes. Verified through the real packaging path (`homey app validate` → CLI copy → `npm run build`):

```
<link href="styles.css?v=eb25b355" rel="stylesheet" />
<script defer src="index.js?v=069b961d"></script>
<script data-origin="settings" defer src="/homey.js"></script>
{"settings":"eb25b355.069b961d"}
```

`/homey.js` stays unstamped, the source HTML carries no stamp, and the manifest identity equals the document-order join of the page's unique stamps — the freshness handshake agrees on both sides.

## What the reformat did not change here

Prettier explodes long tags and puts element text on its own line, which pads `textContent` with whitespace. This page's assertions read through `toContain` or through rows the code builds, so none of them moved. (The twin change in com.heatzy did need two assertions reworded — they compared authored fallback text byte for byte.)

The bundler fixture gains Prettier's exploded-tag form. That has teeth: scoping the reference pattern to a single line fails two of its tests.

## Checks

`format`, `lint`, `typecheck` and `homey:validate` all exit 0; 222 tests pass at 100 % statements/branches/functions/lines. `homey:validate` rewrote nothing.