### PR TITLE
fix: read the changelog with syntax every firmware can parse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,8 +303,37 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   project. A `tsconfig.webview.json` floor was probed and refused on
   com.melcloud (2026-08-06): tsc checks the import CLOSURE, which
   crosses into node-side code — the same shape exists here
-  (`settings/` imports shared `lib/` and `types/` modules). Node-side
-  code may use the newer APIs freely.
+  (`settings/` imports shared `lib/` and `types/` modules).
+- TWO floors coexist, on UNRELATED engines — never let one move the
+  other. The **webview** floor is es2023 and is set by the phone's
+  WebKit, which no Homey firmware can rejuvenate: it stays enforced by
+  the scoped lint block above, and the danger there is APIs, because
+  esbuild lowers syntax but NEVER polyfills (`Object.groupBy`, iterator
+  helpers…; the regex `v` flag is the mixed case — syntax esbuild does
+  not lower, hence its place in the same block). The **node-side**
+  floor is the Homey's own Node, and it is held by the manifest's
+  `compatibility` declaration, not by a check.
+- That node-side floor is a DECLARATION, deliberately: two shipped
+  incidents (the regex `v` flag, then `import … with { type: 'json' }`)
+  crashed the app at PARSE time on Homey Pro (2016-2019) firmwares
+  before 13.4, which run a pre-Node-20 engine — a module the engine
+  cannot parse fails BEFORE a line of it runs, so no try/catch anywhere
+  can recover it. A parse-level guard over the emitted build was built
+  and then REFUSED (2026-08): no acorn `ecmaVersion` corresponds to
+  "what Node 22.19 accepts" — es2025 is only partly implemented there
+  (regex modifiers and duplicate named groups are Node 23, `using` is
+  Node 24) — so any calibration is either too lax to catch anything or
+  too strict, forcing rewrites of perfectly valid code. A guard that
+  cannot be calibrated honestly guards nothing; the declaration is the
+  net, kept aligned with the `engines` of the shipped dependencies
+  (`>=22.19.0`). `files.mts` still reads its JSON through
+  `createRequire` — not to satisfy a floor, but because it is the
+  robust form and costs nothing.
+- Node-side runtime APIs above the floor are therefore LEGITIMATE:
+  `toSorted`/`toReversed` (Node 20), `Object.groupBy` (Node 21) and
+  `Promise.withResolvers` (Node 22) all predate the declared engine.
+  Never rewrite one away for compatibility — `pushToUI`'s `toReversed`
+  and `group-devices.mts`'s `toSorted` stay exactly as they are.
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/files.mts
+++ b/files.mts
@@ -1,1 +1,27 @@
-export { default as changelog } from './.homeychangelog.json' with { type: 'json' }
+// `app.mts` loads this module at boot, so the device parses it before
+// running anything: import attributes (`with { type: 'json' }`) are a
+// parse-time SyntaxError on the pre-Node-20 engine of Homey Pro
+// (2016-2019) firmwares before 13.4, and no try/catch can recover a
+// module that never parsed. `createRequire` reads the same file with
+// syntax every engine accepts, while the type-only import keeps tsc's
+// inference and erases at emit.
+import { createRequire } from 'node:module'
+
+import type ChangelogJson from './.homeychangelog.json'
+
+// Binds every readable path to the shape tsc inferred for it, so a
+// mistyped path is a compile error rather than a runtime one.
+interface JsonFiles {
+  './.homeychangelog.json': typeof ChangelogJson
+}
+
+const requireJson = createRequire(import.meta.url)
+
+const loadJson = <TPath extends keyof JsonFiles>(
+  path: TPath,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the module system types every read as `any`; the mapping above restores the shape tsc inferred
+): JsonFiles[TPath] => requireJson(path) as JsonFiles[TPath]
+
+export const changelog: typeof ChangelogJson = loadJson(
+  './.homeychangelog.json',
+)


### PR DESCRIPTION
`app.mts` loads `files.mts` at boot, so the device parses it before running anything: import attributes (`with { type: 'json' }`) are a parse-time SyntaxError on the pre-Node-20 engine of Homey Pro (2016-2019) firmwares before 13.4, and no try/catch can recover a module that never parsed.

This app never shipped its half of the fix: the sibling apps published theirs (com.melcloud 46.2.1, com.heatzy 23.3.1), while here the regex `v` flag correction sits unreleased in `1d273ab2` behind a `build:` subject — so these users have had no working app at all.

`createRequire` reads the same file with syntax every engine accepts, and the type-only import keeps tsc's inference. The mapping binds each readable path to its inferred shape, so a mistyped path is a compile error rather than a runtime one.

CLAUDE.md now states the two floors side by side, since they sit on unrelated engines and confusing them has already cost a production incident: the webview floor (es2023) is the phone's WebKit and stays enforced by the scoped lint block, while the node-side floor is the Homey's own Node and is held by the manifest's `compatibility` declaration. `pushToUI`'s `toReversed` is legitimate at that engine and stays as it is.

Verified through the real packaging path (`homey:validate` → `.homeybuild`): the packaged module loads and returns data identical to the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3