### PR TITLE
chore: drop the expired node-side u-flag verdict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,7 +331,9 @@ start`. Never rename or drop a shipped bundle filename; add alongside. A second 
   claim — `pushToUI`'s `toReversed` and `group-devices.mts`'s
   `toSorted` stay exactly as they are. The same holds for syntax:
   `files.mts` reads its JSON through import attributes, the statically
-  analysable form.
+  analysable form, and node-side regexes take the family's `v` flag —
+  only the webview globs step down to `u`, and that step-down is the
+  scoped block's job, never a second overlay.
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/app.mts
+++ b/app.mts
@@ -192,8 +192,8 @@ export default class MELCloudExtensionApp extends App {
       category: category ?? messageId,
       // Fix i18n grammar: "de el" → "del" (Spanish), "de le" → "du" (French)
       message: (translated === '' ? messageId : translated)
-        .replaceAll(/de el /giu, 'del ')
-        .replaceAll(/de le /giu, 'du '),
+        .replaceAll(/de el /giv, 'del ')
+        .replaceAll(/de le /giv, 'du '),
       time: Temporal.Now.instant().epochMilliseconds,
     }
     this.homey.api.realtime('log', newLog)

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -24,14 +24,6 @@ const config: Config[] = defineConfig([
       'max-classes-per-file': 'off',
     },
   },
-  {
-    // Shipped node code keeps `u`-flag regexes: the `v` flag is a
-    // parse-time SyntaxError on older Homey Pro (2016-2019) firmwares
-    // (pre-Node-20 runtime) — the 2026-08 boot-crash root cause in the
-    // sibling apps.
-    files: ['*.mts', 'lib/**/*.mts'],
-    rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
-  },
 ])
 
 export default config


### PR DESCRIPTION
The eslint overlay pinned `require-unicode-regexp` to `u` over `*.mts` and `lib/**/*.mts`, with this reason: the es2024 `v` flag is a parse-time `SyntaxError` on the pre-Node-20 runtime of older Homey Pro (2016-2019) firmware.

Those globs are **node-side only** — `settings/` keeps its step-down from the preset's own scoped floor block, which serves the phone WebKit engines that no firmware update can rejuvenate. The node-side floor is the Homey's own Node, declared by `compatibility: ">=12.9.0"` (Athom's documented Node 22 boundary), where `v` parses. The pin has nothing left to encode, so it goes.

## Measured, not assumed

Removing the block makes the family default (`v`) fire on **exactly two** regexes, both in `app.mts`:

```
/de el /giu   → /de el /giv
/de le /giu   → /de le /giv
```

Both are literal text with no character class at all, so `u` and `v` are strictly equivalent for them.

## One thing worth stating plainly

These two are the regexes of the 2026-08 boot crash — the `v`→`u` conversion that fixed it has never shipped, and this PR puts `v` back. That is deliberate and costs nothing measurable: an app on that firmware already dies earlier in the same boot, inside `@olivierzal/homey-kit`'s `selectChangelogEntries`, which calls `toSorted` (Node 20). Holding these two regexes at `u` protects a boot that fails a few frames later regardless, at the price of a local exception whose stated reason is dead.

## Doctrine

The "TWO floors coexist" section was already correct. One clause is added where node-side es2022+ APIs are listed as legitimate, naming the regex flag alongside them: the step-down to `u` is the scoped webview block's job, never a second overlay.

## Gates

format · lint (zero disable) · typecheck · 222 tests · **100 % on all four axes** (744/238/214/737) · `homey:validate` at publish level, no rewrite