### PR TITLE
docs: record that Dependabot subject casing cannot be pinned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,13 @@ handshake (the reader fails open with an empty map).
   proper noun. Dependabot's prefixes are pinned to `build(deps)` /
   `build(deps-dev)` rather than inferred, which is what had it land a
   different style in each repo.
+  The **subject** casing stays inferred and cannot be pinned:
+  `commit-message` accepts only `prefix`, `prefix-development` and
+  `include`, so Dependabot keeps matching each repo's own history
+  (`Bump undici` in one, `bump temporal-polyfill` in another). Left
+  alone by decision (2026-08): a Dependabot commit subject is not a
+  contract, the PR title is — and the `PR title` check already holds
+  that one.
 - After every push, monitor the triggered pipelines to completion — the
   PR checks after a push, the publish run after a release tag — and act
   on the outcome: rerun transient infra failures (a SonarCloud 504 is


### PR DESCRIPTION
`commit-message` in `dependabot.yml` accepts only three sub-keys — `prefix`, `prefix-development` and `include` — per the [options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference). **None controls the subject casing**, which Dependabot infers: the docs say commit messages *"follow similar patterns to those detected in the repository"*.

Measured across the family: `melcloud-api` produced *Bump undici*, `com.melcloud.extension` produced *bump temporal-polyfill*. The prefix is pinned on both sides; the casing is not, and cannot be.

Left alone rather than worked around: a Dependabot commit subject is not a contract, the PR title is — and the `PR title` check already holds that one. The verdict is written down so the question is not reopened.