### PR TITLE
chore: drop the merge_group trigger an org-only feature cannot fire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       node-versions: '[{"node-version": "22"}, {"node-version": "22.20", "coverage": true}, {"node-version": "latest"}, {"node-version": "lts/*"}]'
 name: CI
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,6 @@ jobs:
     timeout-minutes: 15
 name: Validate
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,6 @@ jobs:
     uses: OlivierZal/configs/.github/workflows/zizmor.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
 name: zizmor
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]


### PR DESCRIPTION
GitHub gates merge queues on **organisation ownership**. From the docs source ([`gated-features/merge-queue`](https://github.com/github/docs/blob/main/data/reusables/gated-features/merge-queue.md)):

> Pull request merge queues are available in any public repository **owned by an organization**, or in private repositories owned by organizations using GitHub Enterprise Cloud.

Every repo in this family is public but owned by a **personal account** (`owner.type = User`, checked on all seven). The `merge_group` event therefore cannot arrive, and the trigger was configuration for a need that cannot appear.

That is the same standard applied earlier today when an `allow-ghsas` input was kept out of the dependency review — *"no repo needs it; building for a need that has not appeared is precisely what we remove"*. A standard applied in one direction only is not a standard.

The doctrine is corrected where it claimed these triggers were "inert but harmless": inertness is not a reason to keep configuration.