### PR TITLE
fix(lint): floor types.mts and record the commented-reference edges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,13 @@ Run the FULL suite before any push — CI runs all of it:
   The committed source HTML carries NO stamps — never hand-add a `?v=`
   there, and nothing needs re-committing when a settings source changes
   (the old re-stamp-and-commit dance is gone). Stamps exist only in the
-  packaged app, and only within attribute/import reference contexts,
-  never comments.
+  packaged app, within attribute/import reference contexts
+  (`href="`/`src="`) — matched WHEREVER they appear, HTML comments
+  included: a commented reference to a missing file fails the packaging
+  pass, and one to a real file would be stamped by the builder yet
+  invisible to the page-side DOM query, splitting the two identities
+  into an endless refetch handshake. Delete a dead reference, never
+  comment it out.
 - `npm run homey:validate` — Homey validation at publish level; may
   rewrite files (locales), re-stage if it does.
 - `npm run homey:start` — `homey app run --remote` for on-device testing.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,9 @@ const config: Config[] = defineConfig([
       'lib/**/*.mts',
       'listeners/**/*.mts',
     ],
-    webviewFloorFiles: ['settings/**/*.mts'],
+    // `types.mts` is cross-surface: the settings bundle emits its
+    // constants (measured by metafile), so it carries the floor too.
+    webviewFloorFiles: ['settings/**/*.mts', 'types.mts'],
   }),
   {
     // Ambient declaration files: `declare module` blocks parse as scripts,

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -119,8 +119,15 @@ const collectReferences = async (
       ),
   )
 
-// Stamp only within a reference context, so the same filename written
-// elsewhere (e.g. a comment) is never rewritten. Rebuilt cursor-wise
+// Stamp only within a reference context (`href="`/`src="`), so a bare
+// filename written elsewhere (e.g. prose in a comment) is never
+// rewritten. A FULL reference inside an HTML comment still matches:
+// pointing at a missing file it fails the packaging pass (ENOENT);
+// pointing at a real file it earns a stamp the page-side DOM query
+// never sees, splitting the builder identity from the page identity —
+// one refetch, then a boot-error on every open. No page carries a
+// commented reference today; delete, never comment out. Rebuilt
+// cursor-wise
 // rather than through a `replaceAll` callback, whose loosely typed rest
 // arguments cannot carry the named groups safely.
 const stampReferences = (


### PR DESCRIPTION
Two counter-verification findings. (1) `types.mts` emits 14 bytes of runtime code into the settings bundle while sitting outside the webview-floor glob — it joins the floor (cross-surface constants belong under it; moving them into `settings/` would invert the import direction). (2) The stamping docstring's comment-safety claim only holds for bare filenames: a full commented reference either fails the packaging pass (missing file, ENOENT) or splits the builder identity from the page identity (existing file — stamped by the builder, invisible to the page's DOM query, refetch then boot-error per open). No page carries a commented reference today; the contract is now written where the regex lives and in CLAUDE.md: delete a dead reference, never comment it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3