### PR TITLE
build: adopt @olivierzal/configs 4.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
     with:
       # The fleet's floor, measured on-device (2026-08): 22.20 on a Pro
       # 2019, 22.23 on a Pro 2023. `22` resolves to the head of the line

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
     with:
       repo-guidance: 'The app ids `com.mecloud` and `com.mecloud.extension` carry a load-bearing historical typo — never "correct" the spelling anywhere (manifest, code, docs or links). When the bump is `@olivierzal/configs`, move the workflow `uses:` refs to the tag the npm pin names, since one version covers both channels, and resolve every version comment against the upstream with `git ls-remote --tags` instead of guessing it. Stop and leave the PR red when the release changes lint policy: adopting that needs a per-repo verdict, not an automated fix.'
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`, and `npm run homey:validate`'

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: zizmor
 on:
   pull_request: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "temporal-polyfill": "^1.0.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.0.0",
+        "@olivierzal/configs": "4.0.1",
         "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.0/e9c57bdad07904b2daa123538bf5408db87d430e",
-      "integrity": "sha512-ERblKVcsjHmoOWvo97q3U7Qk3IrzgzCkwgW4pfe53RETUb+f0Xh+2Woqubr3jmdi7I9aBw36FeE/IRMyTyD+Lw==",
+      "version": "4.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.1/baaf00059f15b95f4f339311beb52db55658bf4a",
+      "integrity": "sha512-gz7mQl4K2OA9H3qMrzt5Y2dOCMG9UhIorxQoK8G12+KYzSuG2PxhBiqakDGsIVtxdfCPpLiW/6hC3juTeUG5Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "temporal-polyfill": "^1.0.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.0.0",
+    "@olivierzal/configs": "4.0.1",
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
Adopts configs 4.0.1 — the release that carries OlivierZal/configs#57's corrected webview-floor doctrine into the installed artifact. Both channels move together: the npm pin to `4.0.1`, every workflow ref to `1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1`.

Iso-behavior: `eslint --print-config` on `settings/index.mts` and `app.mts` differs from 4.0.0 only in `message` strings (4 lines, all in the webview-floor overlay of `settings/index.mts`; `app.mts` is byte-identical) — selectors, globs and severities untouched. Not a policy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
