### PR TITLE
chore(release): 25.3.2

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -793,5 +793,20 @@
     "pl": "Otrzymujesz teraz również powiadomienia o zmianach z pominiętych wersji.",
     "ru": "Теперь вы также получаете уведомления об изменениях в пропущенных версиях.",
     "sv": "Du meddelas nu även om ändringarna från versioner du hoppat över."
+  },
+  "25.3.2": {
+    "ar": "إصلاح تعذّر تشغيل التطبيق على Homey Pro (2016 – 2019) بنظام تشغيل قديم.",
+    "da": "Retter at appen ikke kunne starte på Homey Pro (2016 – 2019) med ældre firmware.",
+    "de": "Behebt, dass die App auf dem Homey Pro (2016 – 2019) mit älterer Firmware nicht starten konnte.",
+    "en": "Fixes the app failing to start on Homey Pro (2016 – 2019) running older firmware.",
+    "es": "Corrige que la aplicación no se iniciara en Homey Pro (2016 – 2019) con firmware antiguo.",
+    "fr": "Corrige l'impossibilité de démarrer l'app sur Homey Pro (2016 – 2019) sous un firmware ancien.",
+    "it": "Corregge l'impossibilità di avviare l'app su Homey Pro (2016 – 2019) con firmware datato.",
+    "ko": "이전 펌웨어를 사용하는 Homey Pro(2016 – 2019)에서 앱이 시작되지 않던 문제를 수정했습니다.",
+    "nl": "Lost op dat de app niet startte op Homey Pro (2016 – 2019) met oudere firmware.",
+    "no": "Retter at appen ikke startet på Homey Pro (2016 – 2019) med eldre fastvare.",
+    "pl": "Naprawia problem z uruchamianiem aplikacji na Homey Pro (2016 – 2019) ze starszym oprogramowaniem.",
+    "ru": "Исправлен запуск приложения на Homey Pro (2016 – 2019) со старой прошивкой.",
+    "sv": "Åtgärdar att appen inte startade på Homey Pro (2016 – 2019) med äldre firmware."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -198,5 +198,5 @@
       "värmepump"
     ]
   },
-  "version": "25.3.1"
+  "version": "25.3.2"
 }

--- a/app.json
+++ b/app.json
@@ -199,5 +199,5 @@
       "värmepump"
     ]
   },
-  "version": "25.3.1"
+  "version": "25.3.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.3.1",
+  "version": "25.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.melcloud.extension",
-      "version": "25.3.1",
+      "version": "25.3.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@olivierzal/homey-kit": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.melcloud.extension",
-  "version": "25.3.1",
+  "version": "25.3.2",
   "description": "Extension for MELCloud Homey App",
   "homepage": "https://github.com/OlivierZal/com.melcloud.extension/",
   "bugs": {


### PR DESCRIPTION
Cuts the release that finally ships #1286 to the store: the current 25.3.1 still fails to start on Homey Pro (2016 – 2019) running older firmware — the fix has sat on main since it was merged. Changelog entry in the thirteen languages.